### PR TITLE
Add GitHub action to build Next.js app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Next.js App
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Next.js app
+        run: npm run build


### PR DESCRIPTION
Fixes #13

Add a GitHub action to build the Next.js app on all pull requests.

* **GitHub Action Configuration**: Add `.github/workflows/build.yml` to define the GitHub action.
* **Trigger**: Set the action to trigger on pull requests to the `main` branch.
* **Steps**:
  - Checkout the repository using `actions/checkout@v3`.
  - Setup Node.js using `actions/setup-node@v3` with the latest LTS version.
  - Cache node modules using `actions/cache@v3` to speed up the build process.
  - Install dependencies using `npm install`.
  - Build the Next.js app using `npm run build`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/13?shareId=5277cc33-0c25-4792-a1e3-75d9c443a36f).