### PR TITLE
Make header responsive

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,3 +125,27 @@ h3 {
   background-color: white;
   margin-bottom: 20px;
 }
+
+/* Media queries to hide navigation links on screens below 768px */
+@media (max-width: 768px) {
+  .header-links {
+    display: none;
+  }
+}
+
+/* Styles for the Drawer component to ensure it covers the entire screen */
+.MuiDrawer-paper {
+  width: 100%;
+  max-width: 300px;
+}
+
+/* Styles for the MenuIcon component to position it correctly in the header */
+.MuiIconButton-root {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .MuiIconButton-root {
+    display: block;
+  }
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,8 +1,16 @@
 import Image from "next/image";
 import Link from "next/link";
-import { AppBar, Toolbar, Typography, Box } from "@mui/material";
+import { AppBar, Toolbar, Typography, Box, IconButton, Drawer, List, ListItem, ListItemText } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { useState } from "react";
 
 export default function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const handleMenuToggle = () => {
+    setMenuOpen(!menuOpen);
+  };
+
   return (
     <AppBar
       position="static"
@@ -52,7 +60,34 @@ export default function Header() {
             <Typography variant="body1">poängtabell</Typography>
           </Link>
         </Box>
+        <IconButton
+          edge="end"
+          color="inherit"
+          aria-label="menu"
+          onClick={handleMenuToggle}
+          sx={{ display: { xs: "block", md: "none" } }}
+        >
+          <MenuIcon />
+        </IconButton>
       </Toolbar>
+      <Drawer
+        anchor="right"
+        open={menuOpen}
+        onClose={handleMenuToggle}
+        sx={{ display: { xs: "block", md: "none" } }}
+      >
+        <List>
+          <ListItem button component={Link} href="/" onClick={handleMenuToggle}>
+            <ListItemText primary="matcher" />
+          </ListItem>
+          <ListItem button component={Link} href="/statistics" onClick={handleMenuToggle}>
+            <ListItemText primary="statistik" />
+          </ListItem>
+          <ListItem button component={Link} href="/scoreboard" onClick={handleMenuToggle}>
+            <ListItemText primary="poängtabell" />
+          </ListItem>
+        </List>
+      </Drawer>
     </AppBar>
   );
 }


### PR DESCRIPTION
Fixes #17

Make the header responsive by adding a collapsible menu with a hamburger menu icon for smaller screens.

* **Header Component (`src/components/header.tsx`)**
  - Import `MenuIcon`, `Drawer`, `List`, `ListItem`, `ListItemText`, and `useState` from Material-UI.
  - Add a state variable `menuOpen` to manage the menu's open/close state.
  - Add a `handleMenuToggle` function to toggle the `menuOpen` state.
  - Add an `IconButton` component to render the hamburger menu icon, visible on screens below 768px.
  - Add a `Drawer` component to render the collapsible menu, containing navigation links.

* **Global Styles (`src/app/globals.css`)**
  - Add media queries to hide the navigation links on screens below 768px.
  - Add styles for the `Drawer` component to ensure it covers the entire screen.
  - Add styles for the `MenuIcon` component to position it correctly in the header.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/17?shareId=e8c3f1d2-2d2b-48ab-9eae-b8acc014a5cf).