### PR TITLE
Improve look and feel of the score table

### DIFF
--- a/src/app/scoreboard/page.tsx
+++ b/src/app/scoreboard/page.tsx
@@ -1,33 +1,6 @@
 import React from "react";
 import { Metadata } from "next";
-
-const tableStyle: any = {
-  borderCollapse: "collapse",
-  width: "100%",
-  maxWidth: "600px",
-  margin: "20px 0",
-  boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
-};
-
-const thStyle: any = {
-  backgroundColor: "#943030",
-  color: "white",
-  padding: "12px",
-  textAlign: "left",
-};
-
-const tdStyle: any = {
-  border: "1px solid #ddd",
-  padding: "12px",
-};
-
-const listStyle: any = {
-  backgroundColor: "#f9f9f9",
-  borderRadius: "8px",
-  padding: "20px",
-  marginBottom: "20px",
-  boxShadow: "0 2px 4px rgba(0, 0, 0, 0.05)",
-};
+import { Table, TableHead, TableBody, TableRow, TableCell, Paper, Typography, Box } from "@mui/material";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -37,18 +10,19 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default function ScoreboardPage() {
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         padding: "40px",
         fontFamily: "HelveticaNeueLight, Helvetica, Arial, sans-serif",
         maxWidth: "800px",
         margin: "0 auto",
       }}
     >
-      <h1>Poängtabell</h1>
+      <Typography variant="h1">Poängtabell</Typography>
 
-      <h2
-        style={{
+      <Typography
+        variant="h2"
+        sx={{
           color: "#943030",
           fontSize: "28px",
           marginTop: "40px",
@@ -57,76 +31,79 @@ export default function ScoreboardPage() {
         }}
       >
         Ordinarie poäng
-      </h2>
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            <th style={thStyle}></th>
-            <th style={thStyle}>Öppen</th>
-            <th style={thStyle}>Dold</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td style={tdStyle}>Tretal 2-8</td>
-            <td style={tdStyle}>2</td>
-            <td style={tdStyle}>4</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Tretal 1, 9</td>
-            <td style={tdStyle}>4</td>
-            <td style={tdStyle}>8</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Tretal vindar</td>
-            <td style={tdStyle}>4</td>
-            <td style={tdStyle}>8</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Tretal drakar</td>
-            <td style={tdStyle}>4</td>
-            <td style={tdStyle}>8</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Fyrtal 2-8</td>
-            <td style={tdStyle}>8</td>
-            <td style={tdStyle}>16</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Fyrtal 1, 9</td>
-            <td style={tdStyle}>16</td>
-            <td style={tdStyle}>32</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Fyrtal vindar</td>
-            <td style={tdStyle}>16</td>
-            <td style={tdStyle}>32</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Fyrtal drakar</td>
-            <td style={tdStyle}>16</td>
-            <td style={tdStyle}>32</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Par drakar</td>
-            <td style={tdStyle}>2</td>
-            <td style={tdStyle}>2</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Par egen vind</td>
-            <td style={tdStyle}>2</td>
-            <td style={tdStyle}>2</td>
-          </tr>
-          <tr>
-            <td style={tdStyle}>Blomma/årstid</td>
-            <td style={tdStyle}>4</td>
-            <td style={tdStyle}>-</td>
-          </tr>
-        </tbody>
-      </table>
+      </Typography>
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell></TableCell>
+              <TableCell>Öppen</TableCell>
+              <TableCell>Dold</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>Tretal 2-8</TableCell>
+              <TableCell>2</TableCell>
+              <TableCell>4</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Tretal 1, 9</TableCell>
+              <TableCell>4</TableCell>
+              <TableCell>8</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Tretal vindar</TableCell>
+              <TableCell>4</TableCell>
+              <TableCell>8</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Tretal drakar</TableCell>
+              <TableCell>4</TableCell>
+              <TableCell>8</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Fyrtal 2-8</TableCell>
+              <TableCell>8</TableCell>
+              <TableCell>16</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Fyrtal 1, 9</TableCell>
+              <TableCell>16</TableCell>
+              <TableCell>32</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Fyrtal vindar</TableCell>
+              <TableCell>16</TableCell>
+              <TableCell>32</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Fyrtal drakar</TableCell>
+              <TableCell>16</TableCell>
+              <TableCell>32</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Par drakar</TableCell>
+              <TableCell>2</TableCell>
+              <TableCell>2</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Par egen vind</TableCell>
+              <TableCell>2</TableCell>
+              <TableCell>2</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Blomma/årstid</TableCell>
+              <TableCell>4</TableCell>
+              <TableCell>-</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Paper>
 
-      <h2
-        style={{
+      <Typography
+        variant="h2"
+        sx={{
           color: "#943030",
           fontSize: "28px",
           marginTop: "40px",
@@ -135,16 +112,27 @@ export default function ScoreboardPage() {
         }}
       >
         Multiplikatorer
-      </h2>
-      <ul style={listStyle}>
-        <li>Tretal eller fyrtal egen vind: X2</li>
-        <li>Tretal eller fyrtal drakar: X2</li>
-        <li>Tre dolda tre- eller fyrtal: X2</li>
-        <li>Hel stege 1-9 av en sort: X2</li>
-      </ul>
+      </Typography>
+      <Paper>
+        <Box
+          sx={{
+            backgroundColor: "#f9f9f9",
+            borderRadius: "8px",
+            padding: "20px",
+            marginBottom: "20px",
+            boxShadow: "0 2px 4px rgba(0, 0, 0, 0.05)",
+          }}
+        >
+          <Typography>Tretal eller fyrtal egen vind: X2</Typography>
+          <Typography>Tretal eller fyrtal drakar: X2</Typography>
+          <Typography>Tre dolda tre- eller fyrtal: X2</Typography>
+          <Typography>Hel stege 1-9 av en sort: X2</Typography>
+        </Box>
+      </Paper>
 
-      <h2
-        style={{
+      <Typography
+        variant="h2"
+        sx={{
           color: "#943030",
           fontSize: "28px",
           marginTop: "40px",
@@ -153,19 +141,29 @@ export default function ScoreboardPage() {
         }}
       >
         Vinnaren
-      </h2>
-      <ul style={listStyle}>
-        <li>Mahjong: 10</li>
-        <li>Mahjong på egen dragen bricka: 2</li>
-        <li>Dold mahjong på slängd bricka: 2</li>
-        <li>Dold mahjong på egen dragen bricka: X2</li>
-        <li>Mahjong på sista brickan i spelet: X2</li>
-        <li>Mahjong på dragen extrabricka efter Kong: X2</li>
-        <li>Inga poäng: 10</li>
-        <li>En sort och vindar eller drakar: X2</li>
-        <li>Uteslutande en sort: X8</li>
-        <li>Inga stegar: X2</li>
-      </ul>
-    </div>
+      </Typography>
+      <Paper>
+        <Box
+          sx={{
+            backgroundColor: "#f9f9f9",
+            borderRadius: "8px",
+            padding: "20px",
+            marginBottom: "20px",
+            boxShadow: "0 2px 4px rgba(0, 0, 0, 0.05)",
+          }}
+        >
+          <Typography>Mahjong: 10</Typography>
+          <Typography>Mahjong på egen dragen bricka: 2</Typography>
+          <Typography>Dold mahjong på slängd bricka: 2</Typography>
+          <Typography>Dold mahjong på egen dragen bricka: X2</Typography>
+          <Typography>Mahjong på sista brickan i spelet: X2</Typography>
+          <Typography>Mahjong på dragen extrabricka efter Kong: X2</Typography>
+          <Typography>Inga poäng: 10</Typography>
+          <Typography>En sort och vindar eller drakar: X2</Typography>
+          <Typography>Uteslutande en sort: X8</Typography>
+          <Typography>Inga stegar: X2</Typography>
+        </Box>
+      </Paper>
+    </Box>
   );
 }


### PR DESCRIPTION
Fixes #40

Improve the look and feel of the score table by using MUI components.

* Replace custom HTML table with MUI `Table`, `TableHead`, `TableBody`, `TableRow`, `TableCell`, and `Paper` components in `src/app/scoreboard/page.tsx`.
* Ensure the score table is responsive using MUI's built-in responsive components.
* Utilize MUI's `Typography` component for headings and text.
* Apply MUI's `Box` component for layout and spacing.
* Remove custom styles for the score table in `src/app/globals.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/40?shareId=1e84aaab-a919-4cda-a5f0-1ce503de111c).