### PR TITLE
Make buttons for new match responsive

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,3 +149,24 @@ h3 {
     display: block;
   }
 }
+
+/* Pfad8 */
+.create-match-button {
+  background-color: #943030;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+/* Pcde0 */
+@media (max-width: 768px) {
+  .create-match-button {
+    width: 100%;
+    padding: 15px;
+    font-size: 18px;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,33 +23,24 @@ export default async function Home() {
 
   return (
     <>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "20px" }}>
-            <h1 style={{ margin: 0, color: "#943030", fontFamily: "HelveticaNeueLight, Helvetica, tahoma, arial", fontSize: "42px", textAlign: "left" }}>
-              Matcher
-            </h1>
-            <Link href="/match/new" passHref>
-              <button style={{
-                backgroundColor: "#943030",
-                color: "white",
-                border: "none",
-                padding: "10px 20px",
-                borderRadius: "5px",
-                cursor: "pointer",
-                fontSize: "16px",
-                fontWeight: "bold"
-              }}>
-                Skapa ny match
-              </button>
-            </Link>
-          </div>
-          <TotalStatisticsRow/>
-          <Grid container spacing={2} sx={{ marginTop: "20px" }}> {/* P68f5 */}
-            {matches.map((match: { GAME_ID: string }) => (
-              <Grid item xs={12} sm={6} key={match.GAME_ID}> {/* Pe16e */}
-                <MatchGridItem id={match.GAME_ID} />
-              </Grid>
-            ))}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "20px" }}>
+        <h1 style={{ margin: 0, color: "#943030", fontFamily: "HelveticaNeueLight, Helvetica, tahoma, arial", fontSize: "42px", textAlign: "left" }}>
+          Matcher
+        </h1>
+        <Link href="/match/new" passHref>
+          <button className="create-match-button">
+            Skapa ny match
+          </button>
+        </Link>
+      </div>
+      <TotalStatisticsRow/>
+      <Grid container spacing={2} sx={{ marginTop: "20px" }}> {/* P68f5 */}
+        {matches.map((match: { GAME_ID: string }) => (
+          <Grid item xs={12} sm={6} key={match.GAME_ID}> {/* Pe16e */}
+            <MatchGridItem id={match.GAME_ID} />
           </Grid>
+        ))}
+      </Grid>
     </>
   );
 }


### PR DESCRIPTION
Fixes #42

Make the 'Create New Match' button responsive on the start page.

* **CSS Changes**:
  - Add a new CSS class `.create-match-button` in `src/app/globals.css` for the button's style.
  - Add media queries to adjust the button's width, padding, and font size for different screen sizes.

* **Component Changes**:
  - Update `src/app/page.tsx` to use the new CSS class for the 'Create New Match' button.
  - Remove the inline styles for the button in `src/app/page.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/42?shareId=9884b4a6-69b9-4c88-9ded-892244a9d281).