### PR TITLE
Make database calls return empty data when there is no running db

### DIFF
--- a/src/components/totalStatisticsRow.tsx
+++ b/src/components/totalStatisticsRow.tsx
@@ -25,8 +25,8 @@ export default async function TotalStatisticsRow() {
       style={{ marginBottom: "20px", textAlign: "left" }}
     >
       <p>
-        Totalt {stats.totalMatches} matcher, {stats.totalMahjongs} mahjonger på{" "}
-        {stats.totalRounds} omgångar
+        Totalt {stats?.totalMatches} matcher, {stats?.totalMahjongs} mahjonger på{" "}
+        {stats?.totalRounds} omgångar
       </p>
     </div>
   );

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -30,10 +30,45 @@ export default class Connection {
   }
 
   public async getConnection(): Promise<PoolConnection> {
-    return this.pool.getConnection();
+    if (await this.isDatabaseRunning()) {
+      return this.pool.getConnection();
+    } else {
+      return this.getMockConnection();
+    }
   }
 
   public async closePool(): Promise<void> {
     await this.pool.end();
+  }
+
+  private async isDatabaseRunning(): Promise<boolean> {
+    try {
+      const connection = await this.pool.getConnection();
+      await connection.ping();
+      connection.release();
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private getMockConnection(): PoolConnection {
+    return {
+      query: async () => [[]],
+      release: () => {},
+      beginTransaction: async () => {},
+      commit: async () => {},
+      rollback: async () => {},
+      changeUser: async () => {},
+      ping: async () => {},
+      statistics: async () => {},
+      end: async () => {},
+      destroy: () => {},
+      pause: () => {},
+      resume: () => {},
+      escape: (value: any) => value,
+      escapeId: (value: any) => value,
+      format: (sql: string, values: any[]) => sql,
+    } as PoolConnection;
   }
 }


### PR DESCRIPTION
Fixes #45

Modify `src/lib/connection.ts` to return empty data when there is no running database.

* Add `isDatabaseRunning` method to check if the database is running.
* Modify `getConnection` to return a mock connection with empty data if the database is not running.
* Add `getMockConnection` method to provide a mock connection with empty data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/45?shareId=d5e4b97e-5797-46f7-82d5-993b8da87b25).