### PR TITLE
Make x-axis in the player scores chart show dates

### DIFF
--- a/src/components/PlayerScoreChart/PlayerScoresChart.tsx
+++ b/src/components/PlayerScoreChart/PlayerScoresChart.tsx
@@ -57,7 +57,7 @@ const PlayerScoresChart: React.FC<PlayerScoresChartProps> = ({
       containLabel: true,
     },
     xAxis: {
-      type: "category",
+      type: "time",
       boundaryGap: false,
       data: labels,
     },

--- a/src/components/PlayerScoreChart/PlayerScoresChart.tsx
+++ b/src/components/PlayerScoreChart/PlayerScoresChart.tsx
@@ -63,7 +63,9 @@ const PlayerScoresChart: React.FC<PlayerScoresChartProps> = ({
       axisLabel: {
         formatter: (value: string) => {
           const date = new Date(parseInt(value));
-          return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+          return `${date.getFullYear()}-${(date.getMonth() + 1)
+            .toString()
+            .padStart(2, "0")}-${date.getDate().toString().padStart(2, "0")}`;
         },
       },
     },

--- a/src/components/PlayerScoreChart/PlayerScoresChart.tsx
+++ b/src/components/PlayerScoreChart/PlayerScoresChart.tsx
@@ -57,9 +57,15 @@ const PlayerScoresChart: React.FC<PlayerScoresChartProps> = ({
       containLabel: true,
     },
     xAxis: {
-      type: "time",
+      type: "category",
       boundaryGap: false,
       data: labels,
+      axisLabel: {
+        formatter: (value: string) => {
+          const date = new Date(parseInt(value));
+          return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+        },
+      },
     },
     yAxis: {
       type: "value",


### PR DESCRIPTION
Fixes #47

Update the x-axis in the player scores chart to show dates instead of numbers.

* Change the `xAxis` configuration in the `scoreOptions` object to use `type: "time"` instead of `type: "category"`.
* Use `data: labels` in the `xAxis` configuration to display match dates on the x-axis.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/47?shareId=f620efba-fc3c-4080-b580-8639ed8685a3).