### PR TITLE
Reload match chart every second if automatic reload is enabled

### DIFF
--- a/src/components/match/matchChartClient.tsx
+++ b/src/components/match/matchChartClient.tsx
@@ -11,16 +11,33 @@ export default function MatchChartClient({
   autoReload: boolean;
 }) {
   const [data, setData] = useState<any>(null);
+  const [lastRoundCount, setLastRoundCount] = useState<number>(0);
 
   const fetchData = async () => {
     const response = await fetch(`/api/matchChart?matchId=${matchId}`);
     const data = await response.json();
     setData(data);
+    setLastRoundCount(data.hands.length);
   };
 
   useEffect(() => {
     fetchData();
   }, [matchId]);
+
+  useEffect(() => {
+    if (autoReload) {
+      const interval = setInterval(async () => {
+        const response = await fetch(`/api/matchChart?matchId=${matchId}`);
+        const newData = await response.json();
+        if (newData.hands.length > lastRoundCount) {
+          setData(newData);
+          setLastRoundCount(newData.hands.length);
+        }
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }
+  }, [autoReload, matchId, lastRoundCount]);
 
   if (!data) {
     return <CircularProgress />;


### PR DESCRIPTION
Fixes #56

Add automatic reload functionality to match chart.

* **Interval Setup**: Add a `useEffect` to set an interval to fetch data every second if `autoReload` is true.
* **Conditional Update**: Add a check to only update the chart if new rounds have been added since the last fetch.
* **Cleanup**: Clear the interval when the component unmounts to prevent memory leaks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/56?shareId=351646ed-183d-4223-bf12-b32e3edfdd56).