### PR TITLE
Add no-winner to piechart for winners in matchChartClient

### DIFF
--- a/src/components/match/matchChartClient.tsx
+++ b/src/components/match/matchChartClient.tsx
@@ -86,7 +86,7 @@ export default function MatchChartClient({
   }, {});
 
   // Add no-winner team for rounds with no IS_WINNER
-  for (let i = 0; i < numRounds; i++) {
+  for (let i = 1; i < numRounds; i++) {
     const roundHands = hands.slice(i * 4, (i + 1) * 4);
     const hasWinner = roundHands.some((hand: any) => hand.IS_WINNER);
     if (!hasWinner) {
@@ -100,11 +100,12 @@ export default function MatchChartClient({
     value: winCounts[teamId],
     name: teamId === "no-winner" ? "No Winner" : getTeamName(teamId),
     itemStyle: {
-      color: teamId === "no-winner"
-        ? "gray"
-        : teamColors[teamId]
-        ? `rgb(${teamColors[teamId].color_red}, ${teamColors[teamId].color_green}, ${teamColors[teamId].color_blue})`
-        : "transparent", // Use transparent if no color is found
+      color:
+        teamId === "no-winner"
+          ? "transparent"
+          : teamColors[teamId]
+          ? `rgb(${teamColors[teamId].color_red}, ${teamColors[teamId].color_green}, ${teamColors[teamId].color_blue})`
+          : "transparent", // Use transparent if no color is found
       formatter: (params: any) => {
         if (Array.isArray(params)) {
           return params

--- a/src/components/match/matchChartClient.tsx
+++ b/src/components/match/matchChartClient.tsx
@@ -85,16 +85,24 @@ export default function MatchChartClient({
     return acc;
   }, {});
 
-  const totalWins: any = Object.values(winCounts).reduce(
-    (sum: any, count: any) => sum + count,
-    0
-  );
+  // Add no-winner team for rounds with no IS_WINNER
+  for (let i = 0; i < numRounds; i++) {
+    const roundHands = hands.slice(i * 4, (i + 1) * 4);
+    const hasWinner = roundHands.some((hand: any) => hand.IS_WINNER);
+    if (!hasWinner) {
+      winCounts["no-winner"] = (winCounts["no-winner"] || 0) + 1;
+    }
+  }
+
+  const totalWins = numRounds;
 
   const pieData = Object.keys(winCounts).map((teamId) => ({
     value: winCounts[teamId],
-    name: getTeamName(teamId),
+    name: teamId === "no-winner" ? "No Winner" : getTeamName(teamId),
     itemStyle: {
-      color: teamColors[teamId]
+      color: teamId === "no-winner"
+        ? "gray"
+        : teamColors[teamId]
         ? `rgb(${teamColors[teamId].color_red}, ${teamColors[teamId].color_green}, ${teamColors[teamId].color_blue})`
         : "transparent", // Use transparent if no color is found
       formatter: (params: any) => {


### PR DESCRIPTION
Fixes #58

Add no-winner team to pie chart for rounds with no IS_WINNER in `matchChartClient.tsx`.

* Add a mock no-winner team to the `winCounts` object for rounds with no `IS_WINNER`.
* Update the `totalWins` calculation to include the number of rounds.
* Adjust the `pieData` to include the no-winner team with a specific color (gray).
* Ensure that no-winner is counted only if there is no `IS_WINNER` for a specific round.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/58?shareId=19df84cd-2d70-41c5-9895-57d6c31a94be).