### PR TITLE
Change header styling and layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,12 +5,12 @@
 }
 
 :root {
-  --background-color: rgb(250,250,250);
+  --background-color: white;
   --grey-color: #909090;
   --header-color: #943030;
   --header-font-family: HelveticaNeueLight, Helvetica, tahoma, arial;
   --gradient-start: rgb(229,70,70);
-  --gradient-end: rgb(127,82,49);
+  --gradient-end: rgb(117,62,39);
   --match-item-color: rgb(148, 48, 48);
   --grid-background-color: rgb(250,250,250);
   --grid-background-hover-color: rgb(250,240,240);
@@ -20,12 +20,12 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background-color: rgb(250,250,250);
+    --background-color: white;
     --grey-color: #909090;
     --header-color: #943030;
     --header-font-family: HelveticaNeueLight, Helvetica, tahoma, arial;
     --gradient-start: rgb(229,70,70);
-    --gradient-end: rgb(127,82,49);
+    --gradient-end: rgb(117,62,39);
     --match-item-color: rgb(148, 48, 48);
     --grid-background-color: rgb(250,250,250);
     --grid-background-hover-color: rgb(250,240,240);
@@ -89,12 +89,37 @@ h3 {
     color: var(--header-color);
 }
 
-.header-text {
-  margin-left: 15px;
-  color: var(--white);
+.header-bar {
+	height: 80px;
+	padding-top:14px;
+	padding-left:6px;
+	padding-right:10px;
+	color: var(--white);
   font-weight: 300;
   text-align: left;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
+  text-transform:uppercase;
+  font-size: 0.9em;
+}
+
+.header-logo {
+  height: 48px;
+  width: auto;
+  position:relative;
+  top: -5px;
+}
+
+.header-title {
+  margin-left: 20px;
+ }
+
+.header-link {
+  margin-left: 15px;
+  font-size: 0.9em;
+}
+
+.header-link:hover {
+  font-weight: 600;
 }
 
 .header-links {
@@ -109,6 +134,14 @@ h3 {
   margin-right: 20px;
   cursor: pointer;
 }
+
+
+
+.content-container {
+	padding-top: 20px;
+}
+
+
 
 .match-round-info {
   margin: 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,14 +19,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Container>
+      <Header />
+        <Container className="content-container">
           <Box
             sx={{
               margin: "0 auto",
               backgroundColor: "var(--white)",
             }}
           >
-            <Header />
             <Box 
       sx={{
         margin: "20px"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -32,6 +32,7 @@ export default function Header() {
       sx={{
         background:
           "radial-gradient(circle farthest-corner at 100px 100px, var(--gradient-start) 0% , var(--gradient-end) 100%)",
+          boxShadow: 0,
       }}
     >
       <Toolbar>
@@ -43,49 +44,44 @@ export default function Header() {
             <Box
               sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
             >
-              {isLargeScreen && (
-                <Image
+              <Image
                   src="/mahjong_tiles.png"
                   alt="Mahjong Tiles"
-                  width={104}
-                  height={52}
                   className="header-logo"
+                  width="300"
+                  height="200"
                 />
-              )}
-              <Typography
-                  variant="h6"
-                  className="header-text"
-              >
+              <div className="header-title">
                 <span style={{ fontWeight: "700" }}>Mahjong</span> Master System
                 4.0
-              </Typography>
+              </div>
             </Box>
           </Link>
         </Box>
-        <Box className="header-links">
-          <Link
+        <Box className="header-links header-text">
+          <Link className="header-link"
             href="/"
             passHref
           >
-            <Typography variant="body1">matcher</Typography>
+            matcher
           </Link>
-          <Link
+          <Link className="header-link"
             href="/statistics"
             passHref
           >
-            <Typography variant="body1">statistik</Typography>
+            statistik
           </Link>
-          <Link
+          <Link className="header-link"
             href="/scoreboard"
             passHref
           >
-            <Typography variant="body1">poängtabell</Typography>
+            poängtabell
           </Link>
-          <Link
+          <Link className="header-link"
               href="/scorecalculator"
               passHref
           >
-            <Typography variant="body1">poängräknare</Typography>
+            poängräknare
           </Link>
         </Box>
         <IconButton


### PR DESCRIPTION
Gjort om styling lite av headern så den ser lite mer fräsigt ut. Även flyttat ur den ur den centrala containerns så den ligger separat längst upp i full-bredd. Samt flyttat en del inline-styling-grejer till globals.css där det nu finns lite nya klasser som styr style för olika delar.

![Screenshot 2024-10-27 at 18 02 09](https://github.com/user-attachments/assets/c7dbf559-5b40-4818-868f-547365402ff1)

För att få detta att funka att köra när jag skulle göra detta råkade jag som sagt uppdatera till NextJS 15.0.1, vilket verkar orsakat en del andra ändringar som jag inte räknat med. Dessa har jag inte tagit med i denna PR dock, så förhoppningen är att dessa style-ändringar borde funka lika bra i den gamla NextJS 14.2 som användes tidigare. 

Och kanske kan jag rulla tillbaka på något sätt till den också? Och slänga justeringarna uppdateringen till 15 gjorde till mina lokala package.json och tsconfig.json? Eller fortsätta använda 15 men slänga justeringarna så den går tillbaka till de tidigare? Mycket oklart vad som är bästa att göra i detta läge för mig. Kanske att du också uppdaterar till 15 i main så att allt blir rätt konfigurerat i där, och så kan jag bara använda det och slänga de som nu finns kvar ocommittade här på denna branch? 