### PR TITLE
Fix spacing issue in TotalStatisticsRow component

### DIFF
--- a/src/components/totalStatisticsRow.tsx
+++ b/src/components/totalStatisticsRow.tsx
@@ -12,7 +12,7 @@ export default async function TotalStatisticsRow() {
       }}
     >
       <p>
-        Totalt {stats?.totalMatches} matcher,
+        Totalt {stats?.totalMatches} matcher,{' '}
         {stats?.totalMahjongs} mahjonger på {stats?.totalRounds - stats?.totalMatches} omgångar
       </p>
     </div>


### PR DESCRIPTION
Fixes #68

Add a space after the comma in the `TotalStatisticsRow` component.

* Modify `src/components/totalStatisticsRow.tsx` to include `{' '}` after the comma in the line displaying total matches and mahjongs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/68?shareId=bbc339e7-e4e1-4d68-adcd-5f94e9b0160d).