### PR TITLE
Add avatar with first initial in header when logged in

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,9 +31,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           [token.email]
         );
         if (rows.length > 0) {
+          const player = rows[0];
+          const firstInitial = player.NAME.charAt(0).toUpperCase();
           session.user = {
             ...session.user,
-            ...rows[0],
+            ...player,
+            firstInitial,
           };
         }
         return session;

--- a/src/components/headerClient.tsx
+++ b/src/components/headerClient.tsx
@@ -11,6 +11,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Avatar,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import { useState } from "react";
@@ -88,6 +89,19 @@ export default function HeaderClient({ session }: { readonly session: any }) {
             Logga in
           </Link>
       }
+      {session?.user && (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Avatar sx={{ bgcolor: "primary.main", marginRight: 2 }}>
+            {session.user.firstInitial}
+          </Avatar>
+          <Link className="header-link"
+              href="/api/auth/signout"
+              passHref
+          >
+            Logga ut
+          </Link>
+        </Box>
+      )}
         </Box>
         <IconButton
           edge="end"


### PR DESCRIPTION
Fixes #78

Add avatar with first initial to header when logged in

* **src/auth.ts**
  - Extract the first initial from the player's name and include it in the session object.
* **src/components/headerClient.tsx**
  - Add a new component to render the avatar with the first initial.
  - Add conditional rendering to display the avatar only when the user is logged in.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/78?shareId=c024e87b-ffe0-4438-a9e7-fbb52e5950ac).