### PR TITLE
Add a profile page for logged in users

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,20 @@
+import { getSession } from "next-auth/react";
+
+export default async function ProfilePage() {
+  const session = await getSession();
+
+  if (!session) {
+    return <p>Du måste vara inloggad för att se denna sida.</p>;
+  }
+
+  const { user } = session;
+  const { name, color } = user;
+
+  return (
+    <div style={{ backgroundColor: "var(--background-color)", padding: "20px" }}>
+      <h1 style={{ color: "var(--header-color)" }}>Profil</h1>
+      <p style={{ color: "var(--label_text-color)" }}>Namn: {name}</p>
+      <p style={{ color: color }}>Färg: {color}</p>
+    </div>
+  );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -37,6 +37,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             ...session.user,
             ...player,
             firstInitial,
+            color: player.COLOR, // Include the user's color in the session data
           };
         }
         return session;

--- a/src/components/headerClient.tsx
+++ b/src/components/headerClient.tsx
@@ -95,6 +95,12 @@ export default function HeaderClient({ session }: { readonly session: any }) {
             {session.user.firstInitial}
           </Avatar>
           <Link className="header-link"
+              href="/profile"
+              passHref
+          >
+            Profil
+          </Link>
+          <Link className="header-link"
               href="/api/auth/signout"
               passHref
           >
@@ -148,6 +154,15 @@ export default function HeaderClient({ session }: { readonly session: any }) {
           >
             <ListItemText primary="Poängräknare" />
           </ListItem>
+          {session?.user && (
+            <ListItem
+              component={Link}
+              href="/profile"
+              onClick={handleMenuToggle}
+            >
+              <ListItemText primary="Profil" />
+            </ListItem>
+          )}
         </List>
       </Drawer>
     </AppBar>


### PR DESCRIPTION
Fixes #80

Add a profile page for logged-in users to display their name and color.

* **Profile Page**: Create a new file `src/app/profile/page.tsx` to display the logged-in user's name and color.
* **Header Link**: Update `src/components/headerClient.tsx` to include a link to the profile page when the user is logged in.
* **Session Data**: Update `src/auth.ts` to include the user's color in the session data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/80?shareId=2c1bd90f-c40e-4e8c-b9bc-055addc6fee2).