### PR TITLE
Update profile avatar to use a menu

### DIFF
--- a/src/components/headerClient.tsx
+++ b/src/components/headerClient.tsx
@@ -12,15 +12,26 @@ import {
   ListItem,
   ListItemText,
   Avatar,
+  Menu,
+  MenuItem,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import { useState } from "react";
 
 export default function HeaderClient({ session }: { readonly session: any }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleMenuToggle = () => {
     setMenuOpen(!menuOpen);
+  };
+
+  const handleAvatarClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
   };
 
   return (
@@ -91,21 +102,27 @@ export default function HeaderClient({ session }: { readonly session: any }) {
       }
       {session?.user && (
         <Box sx={{ display: "flex", alignItems: "center" }}>
-          <Avatar sx={{ bgcolor: "primary.main", marginRight: 2 }}>
-            {session.user.firstInitial}
-          </Avatar>
-          <Link className="header-link"
-              href="/profile"
-              passHref
+          <IconButton onClick={handleAvatarClick}>
+            <Avatar sx={{ bgcolor: "var(--strong-color)", marginRight: 2 }}>
+              {session.user.firstInitial}
+            </Avatar>
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
           >
-            Profil
-          </Link>
-          <Link className="header-link"
-              href="/api/auth/signout"
-              passHref
-          >
-            Logga ut
-          </Link>
+            <MenuItem onClick={handleMenuClose}>
+              <Link href="/profile" passHref>
+                Profil
+              </Link>
+            </MenuItem>
+            <MenuItem onClick={handleMenuClose}>
+              <Link href="/api/auth/signout" passHref>
+                Logga ut
+              </Link>
+            </MenuItem>
+          </Menu>
         </Box>
       )}
         </Box>


### PR DESCRIPTION
Fixes #82

Update `src/components/headerClient.tsx` to use a menu for the profile avatar and change its color.

* Import `Menu` and `MenuItem` from `@mui/material`.
* Add state for `anchorEl` to manage menu open/close.
* Wrap `Avatar` component with `IconButton` and add `onClick` to open menu.
* Add `Menu` component with `MenuItem` for profile and log out links.
* Change `Avatar` color to `var(--strong-color)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/82?shareId=eaf0bf94-a536-466e-9316-d5bcb3ff8c34).