### PR TITLE
Add delete game functionality

### DIFF
--- a/src/app/api/deleteGame/route.ts
+++ b/src/app/api/deleteGame/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { deleteGameById } from '@/lib/dbMatch';
+
+export async function DELETE(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const matchId = searchParams.get('matchId');
+
+  if (!matchId) {
+    return NextResponse.json({ error: 'matchId is required' }, { status: 400 });
+  }
+
+  try {
+    await deleteGameById(matchId);
+    return NextResponse.json({ message: 'Game deleted successfully' }, { status: 200 });
+  } catch (error) {
+    console.error('Error deleting game:', error);
+    return NextResponse.json({ error: 'Failed to delete game' }, { status: 500 });
+  }
+}

--- a/src/app/match/[matchId]/edit/page.tsx
+++ b/src/app/match/[matchId]/edit/page.tsx
@@ -1,7 +1,9 @@
-import { getMatchById } from "@/lib/dbMatch";
+import { getMatchById, getHandsByGameId } from "@/lib/dbMatch";
 import MatchChart from "@/components/match/matchChart";
 import RegisterResultControls from "@/components/match/RegisterResultControls";
 import { Metadata } from "next";
+import { useRouter } from "next/router";
+import { useState } from "react";
 
 interface PageProps {
   readonly params: {
@@ -19,6 +21,36 @@ export async function generateMetadata({
 }
 
 export default async function Page({ params }: PageProps) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [hands, setHands] = useState([]);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const response = await fetch(`/api/deleteGame?matchId=${params.matchId}`, {
+        method: "DELETE",
+      });
+      if (response.ok) {
+        router.push("/matches");
+      } else {
+        console.error("Failed to delete game");
+      }
+    } catch (error) {
+      console.error("Error deleting game:", error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetchHands = async () => {
+      const handsData = await getHandsByGameId(params.matchId);
+      setHands(handsData);
+    };
+    fetchHands();
+  }, [params.matchId]);
+
   return (
     <>
       <MatchChart
@@ -26,6 +58,11 @@ export default async function Page({ params }: PageProps) {
         autoReload={false}
       />
       <RegisterResultControls matchId={params.matchId} />
+      {hands.length <= 4 && (
+        <button onClick={handleDelete} disabled={isDeleting}>
+          {isDeleting ? "Raderar..." : "Radera spel"}
+        </button>
+      )}
     </>
   );
 }

--- a/src/lib/dbMatch.ts
+++ b/src/lib/dbMatch.ts
@@ -232,3 +232,20 @@ export async function getTeamDetails(): Promise<{
     connection.release();
   }
 }
+
+export async function deleteGameById(gameId: string): Promise<void> {
+  const connection = await Connection.getInstance().getConnection();
+  try {
+    await connection.beginTransaction();
+
+    await connection.query('DELETE FROM Hands WHERE GAME_ID = ?', [gameId]);
+    await connection.query('DELETE FROM Games WHERE GAME_ID = ?', [gameId]);
+
+    await connection.commit();
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
+}


### PR DESCRIPTION
Fixes #85

Add functionality to delete games with no rounds except the zero round.

* Add a new API endpoint in `src/app/api/deleteGame/route.ts` to handle game deletion.
* Update `src/app/match/[matchId]/edit/page.tsx` to include a delete button for games with no rounds except the zero round.
* Implement a function to handle the delete button click and call the new API endpoint to delete the game.
* Redirect to the matches list page after successful deletion.
* Hide the delete button if there are rounds and translate the delete button text to Swedish.
* Add a new function `deleteGameById` in `src/lib/dbMatch.ts` to delete a game by its ID and associated hands from the database.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/85?shareId=c6094eea-4e95-476b-abff-6d9b405fca1f).