### PR TITLE
Add profile settings for updating color and SHOW_PREVIOUS_ROUND_SCORE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next": "14.2.10",
         "next-auth": "^5.0.0-beta.25",
         "react": "^18",
+        "react-colorful": "^5.6.1",
         "react-dom": "^18",
         "uuid": "^10.0.0"
       },
@@ -2063,6 +2064,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "14.2.10",
     "next-auth": "^5.0.0-beta.25",
     "react": "^18",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18",
     "uuid": "^10.0.0"
   },

--- a/src/app/api/updateProfile/route.ts
+++ b/src/app/api/updateProfile/route.ts
@@ -1,16 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from 'next-auth/react';
 import Connection from '@/lib/connection';
+import { auth } from "@/auth";
 
 export async function POST(req: NextRequest) {
-  const session = await getSession({ req });
+  const session = await auth();
 
   if (!session || !session.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  console.log(session);
+
   const { color_red, color_green, color_blue, show_previous_round_score } = await req.json();
-  const playerId = session.user.playerId;
+  const playerId = (session.user as any).playerId;
+
+  if (!playerId) {
+    throw new Error("Incorrect playerId");
+  }
+
+  console.log("Updating profile: " + playerId);
 
   const connection = await Connection.getInstance().getConnection();
   try {

--- a/src/app/api/updateProfile/route.ts
+++ b/src/app/api/updateProfile/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from 'next-auth/react';
+import Connection from '@/lib/connection';
+
+export async function POST(req: NextRequest) {
+  const session = await getSession({ req });
+
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { color_red, color_green, color_blue, show_previous_round_score } = await req.json();
+  const playerId = session.user.playerId;
+
+  const connection = await Connection.getInstance().getConnection();
+  try {
+    await connection.query(
+      `UPDATE Players SET COLOR_RED = ?, COLOR_GREEN = ?, COLOR_BLUE = ?, SHOW_PREVIOUS_ROUND_SCORE = ? WHERE PLAYER_ID = ?`,
+      [color_red, color_green, color_blue, show_previous_round_score, playerId]
+    );
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error('Error updating profile:', error);
+    return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 });
+  } finally {
+    connection.release();
+  }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,7 +1,5 @@
 import { auth } from "@/auth";
-import { useState } from "react";
-import { TextField, Button, Checkbox, FormControlLabel, Snackbar, Alert } from "@mui/material";
-import { ChromePicker } from "react-color";
+import ProfilePageClient from "@/components/profile/ProfilePageClient"
 
 export default async function ProfilePage() {
   const session = await auth();
@@ -10,99 +8,7 @@ export default async function ProfilePage() {
     return <p>Du måste vara inloggad för att se denna sida.</p>;
   }
 
-  const user: any = session.user;
-
-  const [color, setColor] = useState({
-    r: user.COLOR_RED,
-    g: user.COLOR_GREEN,
-    b: user.COLOR_BLUE,
-  });
-  const [showPreviousRoundScore, setShowPreviousRoundScore] = useState(
-    user.SHOW_PREVIOUS_ROUND_SCORE
-  );
-  const [snackbarOpen, setSnackbarOpen] = useState(false);
-  const [snackbarMessage, setSnackbarMessage] = useState("");
-  const [snackbarSeverity, setSnackbarSeverity] = useState<"success" | "error">("success");
-
-  const handleColorChange = (color: any) => {
-    setColor(color.rgb);
-  };
-
-  const handleCheckboxChange = (event: any) => {
-    setShowPreviousRoundScore(event.target.checked);
-  };
-
-  const handleSubmit = async (event: any) => {
-    event.preventDefault();
-    const response = await fetch("/api/updateProfile", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        color_red: color.r,
-        color_green: color.g,
-        color_blue: color.b,
-        show_previous_round_score: showPreviousRoundScore,
-      }),
-    });
-
-    if (response.ok) {
-      setSnackbarMessage("Profile updated successfully!");
-      setSnackbarSeverity("success");
-    } else {
-      setSnackbarMessage("Failed to update profile.");
-      setSnackbarSeverity("error");
-    }
-    setSnackbarOpen(true);
-  };
-
-  const handleSnackbarClose = () => {
-    setSnackbarOpen(false);
-  };
-
   return (
-    <div style={{ backgroundColor: "var(--background-color)", padding: "20px" }}>
-      <h1 style={{ color: "var(--header-color)" }}>Profil</h1>
-      <p style={{ color: "var(--label_text-color)" }}>Namn: {user?.name}</p>
-      <div>
-        <p>Färg</p>
-        <ChromePicker
-          color={color}
-          onChange={handleColorChange}
-        />
-      </div>
-      <div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={showPreviousRoundScore}
-              onChange={handleCheckboxChange}
-            />
-          }
-          label="Visa föregående rundpoäng"
-        />
-      </div>
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={handleSubmit}
-      >
-        Uppdatera profil
-      </Button>
-      <Snackbar
-        open={snackbarOpen}
-        autoHideDuration={6000}
-        onClose={handleSnackbarClose}
-      >
-        <Alert
-          onClose={handleSnackbarClose}
-          severity={snackbarSeverity}
-          sx={{ width: '100%' }}
-        >
-          {snackbarMessage}
-        </Alert>
-      </Snackbar>
-    </div>
+    <ProfilePageClient session={session}/>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,22 +1,108 @@
-import { auth } from "@/auth"
+import { auth } from "@/auth";
+import { useState } from "react";
+import { TextField, Button, Checkbox, FormControlLabel, Snackbar, Alert } from "@mui/material";
+import { ChromePicker } from "react-color";
 
 export default async function ProfilePage() {
-  const session = await auth()
+  const session = await auth();
 
-  if (!session || !session.user) {
+  if (!session || !session.user) {
     return <p>Du måste vara inloggad för att se denna sida.</p>;
   }
 
-  const user : any = session.user;
-    
-  console.log(user);
-  console.log(session);
+  const user: any = session.user;
+
+  const [color, setColor] = useState({
+    r: user.COLOR_RED,
+    g: user.COLOR_GREEN,
+    b: user.COLOR_BLUE,
+  });
+  const [showPreviousRoundScore, setShowPreviousRoundScore] = useState(
+    user.SHOW_PREVIOUS_ROUND_SCORE
+  );
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+  const [snackbarSeverity, setSnackbarSeverity] = useState<"success" | "error">("success");
+
+  const handleColorChange = (color: any) => {
+    setColor(color.rgb);
+  };
+
+  const handleCheckboxChange = (event: any) => {
+    setShowPreviousRoundScore(event.target.checked);
+  };
+
+  const handleSubmit = async (event: any) => {
+    event.preventDefault();
+    const response = await fetch("/api/updateProfile", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        color_red: color.r,
+        color_green: color.g,
+        color_blue: color.b,
+        show_previous_round_score: showPreviousRoundScore,
+      }),
+    });
+
+    if (response.ok) {
+      setSnackbarMessage("Profile updated successfully!");
+      setSnackbarSeverity("success");
+    } else {
+      setSnackbarMessage("Failed to update profile.");
+      setSnackbarSeverity("error");
+    }
+    setSnackbarOpen(true);
+  };
+
+  const handleSnackbarClose = () => {
+    setSnackbarOpen(false);
+  };
 
   return (
     <div style={{ backgroundColor: "var(--background-color)", padding: "20px" }}>
       <h1 style={{ color: "var(--header-color)" }}>Profil</h1>
       <p style={{ color: "var(--label_text-color)" }}>Namn: {user?.name}</p>
-      <p style={{ color: user?.color }}>Färg</p>
+      <div>
+        <p>Färg</p>
+        <ChromePicker
+          color={color}
+          onChange={handleColorChange}
+        />
+      </div>
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={showPreviousRoundScore}
+              onChange={handleCheckboxChange}
+            />
+          }
+          label="Visa föregående rundpoäng"
+        />
+      </div>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleSubmit}
+      >
+        Uppdatera profil
+      </Button>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={handleSnackbarClose}
+      >
+        <Alert
+          onClose={handleSnackbarClose}
+          severity={snackbarSeverity}
+          sx={{ width: '100%' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }

--- a/src/components/headerClient.tsx
+++ b/src/components/headerClient.tsx
@@ -20,18 +20,9 @@ import { useState } from "react";
 
 export default function HeaderClient({ session }: { readonly session: any }) {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleMenuToggle = () => {
     setMenuOpen(!menuOpen);
-  };
-
-  const handleAvatarClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
   };
 
   return (
@@ -101,29 +92,14 @@ export default function HeaderClient({ session }: { readonly session: any }) {
           </Link>
       }
       {session?.user && (
-        <Box sx={{ display: "flex", alignItems: "center" }}>
-          <IconButton onClick={handleAvatarClick}>
-            <Avatar sx={{ bgcolor: "var(--strong-color)", marginRight: 2 }}>
-              {session.user.firstInitial}
-            </Avatar>
-          </IconButton>
-          <Menu
-            anchorEl={anchorEl}
-            open={Boolean(anchorEl)}
-            onClose={handleMenuClose}
-          >
-            <MenuItem onClick={handleMenuClose}>
-              <Link href="/profile" passHref>
-                Profil
-              </Link>
-            </MenuItem>
-            <MenuItem onClick={handleMenuClose}>
-              <Link href="/api/auth/signout" passHref>
-                Logga ut
-              </Link>
-            </MenuItem>
-          </Menu>
-        </Box>
+          <>
+            <Link className="header-link"
+                  href="/profile"
+                  passHref
+            >
+              {session.user.name}
+            </Link>
+          </>
       )}
         </Box>
         <IconButton

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -1,0 +1,96 @@
+"use client"
+import React, { useState } from "react";
+import {Button, FormGroup, FormControlLabel, Switch, Snackbar, Alert } from "@mui/material";
+import { RgbColorPicker } from "react-colorful";
+
+interface ComponentParams {
+    readonly session: any
+}
+
+
+export default function ProfilePageClient({ session }: ComponentParams) {
+    const user: any = session.user;
+
+    const [color, setColor] = useState({
+        r: user.COLOR_RED,
+        g: user.COLOR_GREEN,
+        b: user.COLOR_BLUE,
+    });
+    const [showPreviousRoundScore, setShowPreviousRoundScore] = useState(
+        user.SHOW_PREVIOUS_ROUND_SCORE
+    );
+    const [snackbarOpen, setSnackbarOpen] = useState(false);
+    const [snackbarMessage, setSnackbarMessage] = useState("");
+    const [snackbarSeverity, setSnackbarSeverity] = useState<"success" | "error">("success");
+
+    const handleColorChange = (color: any) => {
+        setColor(color.rgb);
+    };
+
+    const handleCheckboxChange = (event: any) => {
+        setShowPreviousRoundScore(event.target.checked);
+    };
+
+    const handleSubmit = (event: any) => {
+        event.preventDefault();
+        fetch("/api/updateProfile", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                color_red: color.r,
+                color_green: color.g,
+                color_blue: color.b,
+                show_previous_round_score: showPreviousRoundScore,
+            }),
+        })
+            .then(() => {
+                setSnackbarMessage("Profile updated successfully!");
+                setSnackbarSeverity("success");
+                setSnackbarOpen(true);
+            }).catch(() => {
+                setSnackbarMessage("Failed to update profile.");
+                setSnackbarSeverity("error");
+                setSnackbarOpen(true);
+            })
+    };
+
+    const handleSnackbarClose = () => {
+        setSnackbarOpen(false);
+    };
+
+    return (
+        <div style={{ backgroundColor: "var(--background-color)"}}>
+            <h1 style={{paddingBottom: "10px" }}>Profil</h1>
+            <p style={{ paddingBottom: "10px" }}>Namn: {user?.name}</p>
+            <div>
+                <div style={{paddingBottom: "20px"}}>Färg</div>
+                <RgbColorPicker color={color} onChange={setColor} />
+            </div>
+            <FormGroup style={{ paddingTop: "20px", paddingBottom: "20px" }}>
+                 <FormControlLabel control={<Switch checked={showPreviousRoundScore} onChange={handleCheckboxChange}  />} label="Visa föregående rundpoäng" />
+            </FormGroup>
+            <Button
+                variant="contained"
+                color="primary"
+                onClick={handleSubmit}
+            >
+                Uppdatera profil
+            </Button>
+            <Snackbar
+                open={snackbarOpen}
+                autoHideDuration={6000}
+                onClose={handleSnackbarClose}
+            >
+                <Alert
+                    onClose={handleSnackbarClose}
+                    severity={snackbarSeverity}
+                    sx={{ width: '100%' }}
+                >
+                    {snackbarMessage}
+                </Alert>
+            </Snackbar>
+        </div>
+    );
+}


### PR DESCRIPTION
Fixes #91

Add profile settings for updating color and SHOW_PREVIOUS_ROUND_SCORE.

* Modify `src/app/profile/page.tsx` to include UI elements for updating color and SHOW_PREVIOUS_ROUND_SCORE.
  - Add color picker from MUI for updating COLOR_RED, COLOR_BLUE, and COLOR_GREEN.
  - Add checkbox for updating SHOW_PREVIOUS_ROUND_SCORE.
  - Add form submission logic to handle profile updates.
  - Use MUI component instead of alert for form submission feedback.
* Add `src/app/api/updateProfile/route.ts` to handle backend updates for profile settings.
  - Validate session and update Players table using session.user.playerId.
* Modify `src/auth.ts` to include logic to update player data including color and SHOW_PREVIOUS_ROUND_SCORE.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/91?shareId=8d081398-4509-4074-8a84-e3c3d5e6209d).