### PR TITLE
Add logout button to profile page

### DIFF
--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -78,6 +78,14 @@ export default function ProfilePageClient({ session }: ComponentParams) {
             >
                 Uppdatera profil
             </Button>
+            <Button
+                variant="contained"
+                color="secondary"
+                href="/api/auth/signout"
+                style={{ marginTop: "20px" }}
+            >
+                Logga ut
+            </Button>
             <Snackbar
                 open={snackbarOpen}
                 autoHideDuration={6000}


### PR DESCRIPTION
Fixes #93

Add a logout button to the profile page.

* Add a `Button` component at the bottom of the profile page in `src/components/profile/ProfilePageClient.tsx`.
* Set the button to use a link to `/api/auth/signout` for logging out.
* Style the button with `variant="contained"`, `color="secondary"`, and a top margin of 20px.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/93?shareId=cdb1f5d8-927f-40a0-9ff7-4c9a919979f7).