### PR TITLE
Put each chart on the statistics page in a tab

### DIFF
--- a/src/components/PlayerScoreChart.tsx
+++ b/src/components/PlayerScoreChart.tsx
@@ -1,9 +1,10 @@
 "use client";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import PlayerScoresChart from "./PlayerScoreChart/PlayerScoresChart";
 import MahjongWinsChart from "./PlayerScoreChart/MahjongWinsChart";
 import HighRollerChart from "./PlayerScoreChart/HighRollerChart";
 import AverageHandTable from "./PlayerScoreChart/AverageHandTable";
+import { Tabs, Tab, Box } from "@mui/material";
 
 interface PlayerScoreChartProps {
   matches: any;
@@ -19,6 +20,15 @@ interface PlayerScoreChartProps {
   };
 }
 
+const CustomTabPanel = (props: { value: number; index: number; children: React.ReactNode }) => {
+  const { value, index, children } = props;
+  return (
+    <div role="tabpanel" hidden={value !== index}>
+      {value === index && <Box>{children}</Box>}
+    </div>
+  );
+};
+
 const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
   matches,
   teamIdToName,
@@ -26,6 +36,12 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
   teamIdToPlayerIds,
   playerColors,
 }) => {
+    const [selectedTab, setSelectedTab] = useState(0);
+
+    const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+        setSelectedTab(newValue);
+    };
+
     const {playerScores, labels, mahjongWins, highRollerScores, averageHand, standardDeviations} =
         useMemo(() => {
             const scores: { [key: string]: number[] } = {};
@@ -124,23 +140,37 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
 
     return (
         <div>
-            <PlayerScoresChart
-                playerScores={playerScores}
-                labels={labels}
-                getPlayerColor={getPlayerColor}
-            />
-            <MahjongWinsChart
-                mahjongWins={mahjongWins}
-                getPlayerColor={getPlayerColor}
-            />
-            <HighRollerChart
-                highRollerScores={highRollerScores}
-                getPlayerColor={getPlayerColor}
-            />
-            <AverageHandTable
-                averageHand={averageHand}
-                getPlayerColor={getPlayerColor}
-            />
+            <Tabs value={selectedTab} onChange={handleTabChange}>
+                <Tab label="Player Scores" />
+                <Tab label="Mahjong Wins" />
+                <Tab label="High Roller" />
+                <Tab label="Average Hand" />
+            </Tabs>
+            <CustomTabPanel value={selectedTab} index={0}>
+                <PlayerScoresChart
+                    playerScores={playerScores}
+                    labels={labels}
+                    getPlayerColor={getPlayerColor}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={1}>
+                <MahjongWinsChart
+                    mahjongWins={mahjongWins}
+                    getPlayerColor={getPlayerColor}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={2}>
+                <HighRollerChart
+                    highRollerScores={highRollerScores}
+                    getPlayerColor={getPlayerColor}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={3}>
+                <AverageHandTable
+                    averageHand={averageHand}
+                    getPlayerColor={getPlayerColor}
+                />
+            </CustomTabPanel>
         </div>
     );
 };

--- a/src/components/PlayerScoreChart.tsx
+++ b/src/components/PlayerScoreChart.tsx
@@ -141,10 +141,10 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
     return (
         <div>
             <Tabs value={selectedTab} onChange={handleTabChange}>
-                <Tab label="Player Scores" />
-                <Tab label="Mahjong Wins" />
-                <Tab label="High Roller" />
-                <Tab label="Average Hand" />
+                <Tab label="Poäng" />
+                <Tab label="Andel mahjong" />
+                <Tab label="High Roller-ligan" />
+                <Tab label="Medelhänder" />
             </Tabs>
             <CustomTabPanel value={selectedTab} index={0}>
                 <PlayerScoresChart

--- a/src/components/PlayerScoreChart/HighRollerChart.tsx
+++ b/src/components/PlayerScoreChart/HighRollerChart.tsx
@@ -22,8 +22,7 @@ const HighRollerChart: React.FC<HighRollerChartProps> = ({
   };
 
   return (
-      <div>
-        <h2 style={{ marginBottom: "10px" }}>High Roller-ligan (över 100)</h2>
+      <div style={{ paddingTop: "20px" }}>
         {Object.entries(highRollerScores).map(([player, scores]) => (
             <div
                 key={player}
@@ -72,6 +71,9 @@ const HighRollerChart: React.FC<HighRollerChartProps> = ({
               </div>
             </div>
         ))}
+          <div style={{ fontStyle: "italic", paddingTop: "20px" }}>
+              Streckade cirklar är från när man spelat i lag.
+          </div>
       </div>
   );
 };

--- a/src/components/PlayerScoreChart/PlayerScoresChart.tsx
+++ b/src/components/PlayerScoreChart/PlayerScoresChart.tsx
@@ -46,9 +46,6 @@ const PlayerScoresChart: React.FC<PlayerScoresChartProps> = ({
 
   const scoreOptions = {
     animationDuration: "5000",
-    title: {
-      text: "Poäng",
-    },
     tooltip: {
       trigger: "axis",
     },


### PR DESCRIPTION
Fixes #95

Add MUI Tabs to organize charts on the statistics page.

* Import `Tabs`, `Tab`, and `Box` from `@mui/material` in `src/components/PlayerScoreChart.tsx`.
* Add state to manage the selected tab.
* Create `CustomTabPanel` component to handle tab content display.
* Wrap the charts in `Tabs` and `Box` components.
* Add `Tab` components for each chart: Player Scores, Mahjong Wins, High Roller, and Average Hand.
* Replace direct rendering of charts with `CustomTabPanel` components for each tab.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/issues/95?shareId=9223d5cd-8f98-423d-b694-f8df56dea9e6).