### PR TITLE
Allow update of team names in profile page

### DIFF
--- a/src/app/api/updateTeamName/route.ts
+++ b/src/app/api/updateTeamName/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: NextRequest) {
   }
 
   const { teamId, teamName } = await req.json();
-  const playerId = (session.user as any).playerId;
+  const playerId = session.user.playerId;
 
   if (!playerId) {
     return NextResponse.json({ error: 'Incorrect playerId' }, { status: 500 });

--- a/src/app/api/updateTeamName/route.ts
+++ b/src/app/api/updateTeamName/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Connection from '@/lib/connection';
+import { auth } from "@/auth";
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+
+  if (!session || !session.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { teamId, teamName } = await req.json();
+  const playerId = (session.user as any).playerId;
+
+  if (!playerId) {
+    return NextResponse.json({ error: 'Incorrect playerId' }, { status: 500 });
+  }
+
+  const connection = await Connection.getInstance().getConnection();
+  try {
+    const [rows]: any = await connection.query(
+      `SELECT * FROM Teams WHERE TEAM_ID = ? AND PLAYER_ID = ?`,
+      [teamId, playerId]
+    );
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: 'User is not part of the team' }, { status: 403 });
+    }
+
+    if (teamName === "") {
+      await connection.query(
+        `DELETE FROM TeamAttributes WHERE TEAM_ID = ? AND ATTRIBUTE = 'alias'`,
+        [teamId]
+      );
+    } else {
+      await connection.query(
+        `INSERT INTO TeamAttributes (TEAM_ID, ATTRIBUTE, VALUE) VALUES (?, 'alias', ?)
+         ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)`,
+        [teamId, teamName]
+      );
+    }
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error('Error updating team name:', error);
+    return NextResponse.json({ error: 'Failed to update team name' }, { status: 500 });
+  } finally {
+    connection.release();
+  }
+}

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 import React, { useState, useEffect } from "react";
-import {Box, Button, FormGroup, FormControlLabel, Switch, Snackbar, Alert } from "@mui/material";
+import {Box, Button, FormGroup, FormControlLabel, Switch, Snackbar, Alert, TextField } from "@mui/material";
 import { RgbColorPicker } from "react-colorful";
 import {IdToColorMap, TeamDetails, TeamIdToDetails} from "@/types/db";
 import {Session} from "next-auth";
@@ -102,6 +102,36 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
         setSnackbarOpen(false);
     };
 
+    const handleTeamNameChange = (teamName: string, newTeamName: string) => {
+        setUserTeams((prevTeams) =>
+            prevTeams.map((team) =>
+                team.teamName === teamName ? { ...team, teamName: newTeamName } : team
+            )
+        );
+    };
+
+    const handleTeamNameSubmit = (teamId: string, newTeamName: string) => {
+        fetch("/api/updateTeamName", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                teamId,
+                teamName: newTeamName,
+            }),
+        })
+            .then(() => {
+                setSnackbarMessage("Team name updated successfully!");
+                setSnackbarSeverity("success");
+                setSnackbarOpen(true);
+            }).catch(() => {
+                setSnackbarMessage("Failed to update team name.");
+                setSnackbarSeverity("error");
+                setSnackbarOpen(true);
+            })
+    };
+
     return (
         <div style={{ backgroundColor: "var(--background-color)"}}>
             <h1 style={{paddingBottom: "10px" }}>{user?.name}</h1>
@@ -147,6 +177,19 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
                                 backgroundColor: teamToColor[team.teamName],
                             }}></div>
                         </Box>
+                        <TextField
+                            label="Uppdatera lagnamn"
+                            value={team.teamName}
+                            onChange={(e) => handleTeamNameChange(team.teamName, e.target.value)}
+                            margin="normal"
+                        />
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => handleTeamNameSubmit(team.teamName, team.teamName)}
+                        >
+                            Uppdatera lagnamn
+                        </Button>
                     </div>
                 ))}
             </div>

--- a/src/components/profile/ProfilePageClient.tsx
+++ b/src/components/profile/ProfilePageClient.tsx
@@ -19,11 +19,7 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
         g: user.COLOR_GREEN,
         b: user.COLOR_BLUE,
     });
-    const [userTeams, setUserTeams] = useState<{
-        playerIds: string[];
-        teamName: string;
-        concatenatedName: string;
-    }[]>([]);
+    const [userTeams, setUserTeams] = useState<TeamDetails[]>([]);
 
     const [showPreviousRoundScore, setShowPreviousRoundScore] = useState(
         user.SHOW_PREVIOUS_ROUND_SCORE
@@ -122,11 +118,11 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
             }),
         })
             .then(() => {
-                setSnackbarMessage("Team name updated successfully!");
+                setSnackbarMessage("Uppdaterade " + newTeamName + "!");
                 setSnackbarSeverity("success");
                 setSnackbarOpen(true);
             }).catch(() => {
-                setSnackbarMessage("Failed to update team name.");
+                setSnackbarMessage("Lyckades inte uppdatera: " + newTeamName);
                 setSnackbarSeverity("error");
                 setSnackbarOpen(true);
             })
@@ -152,7 +148,7 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
             <div style={{ paddingTop: "20px" }}>
                 <h2>Dina lag</h2>
                 {userTeams.map((team) => (
-                    <div key={team.teamName} style={{paddingTop: "20px"}}>
+                    <div key={team.id} style={{paddingTop: "20px"}}>
                         <h3>{team.teamName}</h3>
                         <div style={{
                             paddingTop: "10px",
@@ -177,6 +173,11 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
                                 backgroundColor: teamToColor[team.teamName],
                             }}></div>
                         </Box>
+                        <Box style={{
+                            display: "flex",
+                            justifyContent: "left",
+                            alignItems: "center",
+                        }}>
                         <TextField
                             label="Uppdatera lagnamn"
                             value={team.teamName}
@@ -186,10 +187,12 @@ export default function ProfilePageClient({ session, teamDetails, playerColors }
                         <Button
                             variant="contained"
                             color="primary"
-                            onClick={() => handleTeamNameSubmit(team.teamName, team.teamName)}
+                            style={{ marginLeft: "20px" }}
+                            onClick={() => handleTeamNameSubmit(team.id, team.teamName)}
                         >
-                            Uppdatera lagnamn
+                            Uppdatera
                         </Button>
+                        </Box>
                     </div>
                 ))}
             </div>

--- a/src/lib/dbMatch.ts
+++ b/src/lib/dbMatch.ts
@@ -192,3 +192,23 @@ export async function getTeamDetails(): Promise<TeamIdToDetails> {
     connection.release();
   }
 }
+
+export async function updateTeamName(teamId: string, teamName: string): Promise<void> {
+  const connection = await Connection.getInstance().getConnection();
+  try {
+    if (teamName === "") {
+      await connection.query(
+        `DELETE FROM TeamAttributes WHERE TEAM_ID = ? AND ATTRIBUTE = 'alias'`,
+        [teamId]
+      );
+    } else {
+      await connection.query(
+        `INSERT INTO TeamAttributes (TEAM_ID, ATTRIBUTE, VALUE) VALUES (?, 'alias', ?)
+         ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)`,
+        [teamId, teamName]
+      );
+    }
+  } finally {
+    connection.release();
+  }
+}

--- a/src/lib/dbMatch.ts
+++ b/src/lib/dbMatch.ts
@@ -172,15 +172,10 @@ export async function getTeamDetails(): Promise<TeamIdToDetails> {
       GROUP BY Teams.TEAM_ID
     `);
 
-    const teamDetails: {
-      [key: string]: {
-        playerIds: string[];
-        teamName: string;
-        concatenatedName: string;
-      };
-    } = {};
+    const teamDetails: TeamIdToDetails = {};
     result.forEach((row: any) => {
       teamDetails[row.TEAM_ID] = {
+        id: row.TEAM_ID,
         playerIds: row.player_ids.split(","),
         teamName: row.team_name,
         concatenatedName: row.concatenated_name,
@@ -188,26 +183,6 @@ export async function getTeamDetails(): Promise<TeamIdToDetails> {
     });
 
     return teamDetails;
-  } finally {
-    connection.release();
-  }
-}
-
-export async function updateTeamName(teamId: string, teamName: string): Promise<void> {
-  const connection = await Connection.getInstance().getConnection();
-  try {
-    if (teamName === "") {
-      await connection.query(
-        `DELETE FROM TeamAttributes WHERE TEAM_ID = ? AND ATTRIBUTE = 'alias'`,
-        [teamId]
-      );
-    } else {
-      await connection.query(
-        `INSERT INTO TeamAttributes (TEAM_ID, ATTRIBUTE, VALUE) VALUES (?, 'alias', ?)
-         ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)`,
-        [teamId, teamName]
-      );
-    }
   } finally {
     connection.release();
   }

--- a/src/types/db.d.ts
+++ b/src/types/db.d.ts
@@ -55,6 +55,7 @@ export interface TeamIdToPlayerIds {
 }
 
 export interface TeamDetails {
+    id: string;
     playerIds: string[];
     teamName: string;
     concatenatedName: string;


### PR DESCRIPTION
Fixes #113

Add functionality to update team names in the profile page.

* **Backend Changes:**
  - Add a new API endpoint in `src/app/api/updateTeamName/route.ts` to handle updating team names.
  - Validate that the current user is part of the team.
  - Add/update a row in the `TeamAttributes` table with `ATTRIBUTE='alias'`.
  - Remove the row if the team name value is an empty string.

* **Frontend Changes:**
  - Update `src/components/profile/ProfilePageClient.tsx` to include a form for updating team names.
  - Fetch the current team name and allow the user to update it.
  - Submit the updated team name to the new API endpoint.

* **Database Changes:**
  - Update `src/lib/dbMatch.ts` to include a function for updating team names in the `TeamAttributes` table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/josve/mahjong/pull/114?shareId=62477fd5-daef-4d5a-afbc-7d50a677373e).