### PR TITLE
feat: add Högmod statistics tab and escalating streak labels

### DIFF
--- a/src/components/match/LastRoundDisplay.tsx
+++ b/src/components/match/LastRoundDisplay.tsx
@@ -14,6 +14,7 @@ import { motion } from "motion/react";
 import {Round} from "@/components/match/matchChartClient"; // Import motion
 import CastleIcon from '@mui/icons-material/Castle';
 import { orange } from '@mui/material/colors';
+import {getHogmodLabel} from "@/lib/hogmodLabels";
 
 // Create motion-enhanced components
 const MotionGrid = motion(Grid);
@@ -92,7 +93,8 @@ export default function LastRoundDisplay({ teamIdToName, round }: Props) {
                         }
                     }
 
-                    const hogmod = oldHand && oldHand.WIND == 'E' && hand.WIND == 'E';
+                    const eastStreak = round.eastStreaks?.[hand.TEAM_ID] || 0;
+                    const hogmod = eastStreak >= 2;
 
                     const isWinner = hand.IS_WINNER;
                     const isHighroller = hand.HAND >= 100;
@@ -203,7 +205,7 @@ export default function LastRoundDisplay({ teamIdToName, round }: Props) {
 
                                 {hogmod && (
                                     <Chip
-                                        label="Högmod"
+                                        label={getHogmodLabel(eastStreak)}
                                         color="warning"
                                         size="small"
                                         icon={<CastleIcon />}

--- a/src/components/match/matchChartClient.tsx
+++ b/src/components/match/matchChartClient.tsx
@@ -24,6 +24,7 @@ export interface Round {
   previousHand?: Hand[];
   maxHand: number;
   maxScore: number;
+  eastStreaks?: { [teamId: string]: number };
 }
 
 export default function MatchChartClient({
@@ -75,6 +76,7 @@ export default function MatchChartClient({
       const result: Round[] = [];
 
       let prevHand: Hand[] | undefined = undefined;
+      const teamEastStreak: { [teamId: string]: number } = {};
 
       // Process hands in batches of 4 (each ROUND)
       for (let i = 0; i < handsToProcess.length; i += 4) {
@@ -84,12 +86,22 @@ export default function MatchChartClient({
         // Sort the ROUND by TEAM_ID
         const sortedRound = [...round].sort(sortByPlayerId);
 
+        // Track east streaks per team
+        for (const hand of sortedRound) {
+          if (hand.WIND === 'E') {
+            teamEastStreak[hand.TEAM_ID] = (teamEastStreak[hand.TEAM_ID] || 0) + 1;
+          } else {
+            teamEastStreak[hand.TEAM_ID] = 0;
+          }
+        }
+
         // Push the sorted ROUND into the result
         result.push({
           hands: sortedRound,
           previousHand: prevHand,
           maxScore: maxScore,
           maxHand: maxHand,
+          eastStreaks: { ...teamEastStreak },
         });
 
         prevHand = sortedRound;

--- a/src/components/statistics/HogmodChart.tsx
+++ b/src/components/statistics/HogmodChart.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import {MahjongStats} from "@/lib/statistics";
+import {getHogmodLabel} from "@/lib/hogmodLabels";
+import CastleIcon from '@mui/icons-material/Castle';
+import {Tooltip} from "@mui/material";
+
+interface HogmodChartProps {
+    stats: MahjongStats;
+    readonly includeTeams: boolean;
+}
+
+const getIconSize = (streakLength: number) => {
+    const base = 20;
+    return base + (streakLength - 2) * 6;
+};
+
+const getStreakColor = (streakLength: number): string => {
+    if (streakLength >= 7) return "#b71c1c";
+    if (streakLength >= 6) return "#e65100";
+    if (streakLength >= 5) return "#f57f17";
+    if (streakLength >= 4) return "#ff8f00";
+    if (streakLength >= 3) return "#ffa000";
+    return "#ffc107";
+};
+
+const HogmodChart: React.FC<HogmodChartProps> = ({ stats, includeTeams }) => {
+    const playerStats = stats.getDataToShow(includeTeams);
+
+    const sorted = [...playerStats]
+        .filter(d => d.hogmodCount > 0)
+        .sort((a, b) => b.hogmodCount - a.hogmodCount);
+
+    const longestStreakPlayer = [...playerStats]
+        .filter(d => d.longestHogmodStreak > 0)
+        .sort((a, b) => b.longestHogmodStreak - a.longestHogmodStreak)[0];
+
+    return (
+        <div style={{ paddingTop: "20px" }}>
+            {longestStreakPlayer && (
+                <div style={{
+                    marginBottom: "30px",
+                    padding: "16px",
+                    backgroundColor: "#fff8e1",
+                    borderRadius: "8px",
+                    border: "1px solid #ffe082",
+                }}>
+                    <h3 style={{ margin: "0 0 8px 0" }}>
+                        Längsta sviten
+                    </h3>
+                    <div style={{ fontSize: "1.2em" }}>
+                        <strong>{longestStreakPlayer.name}</strong> — {longestStreakPlayer.longestHogmodStreak} rundor i Öst
+                        {" "}({getHogmodLabel(longestStreakPlayer.longestHogmodStreak)})
+                    </div>
+                </div>
+            )}
+
+            {sorted.length === 0 && (
+                <p style={{ fontStyle: "italic" }}>Inga högmod registrerade.</p>
+            )}
+
+            {sorted.map((data) => (
+                <div key={data.id} style={{ marginBottom: "20px" }}>
+                    <h3 style={{ marginBottom: "4px" }}>{data.name}</h3>
+                    <div style={{ marginBottom: "8px", color: "#666" }}>
+                        Totalt: {data.hogmodCount} högmod
+                        {data.longestHogmodStreak >= 2 && (
+                            <> · Längsta svit: {data.longestHogmodStreak} rundor ({getHogmodLabel(data.longestHogmodStreak)})</>
+                        )}
+                    </div>
+                    <div style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "6px",
+                        alignItems: "center",
+                    }}>
+                        {data.hogmodStreaks.map((h) => {
+                            if (includeTeams && h.isTeam && data.isPlayer()) return null;
+                            const size = getIconSize(h.streakLength);
+                            return (
+                                <Tooltip
+                                    key={h.hogmodIndex}
+                                    title={`Spel #${h.gameIndex + 1}: ${h.streakLength} rundor i Öst — ${getHogmodLabel(h.streakLength)}`}
+                                >
+                                    <CastleIcon
+                                        style={{
+                                            fontSize: size,
+                                            color: getStreakColor(h.streakLength),
+                                            opacity: h.isTeam ? 0.5 : 1,
+                                        }}
+                                    />
+                                </Tooltip>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
+            <div style={{ fontStyle: "italic", paddingTop: "20px", color: "#666" }}>
+                Halvtransparenta ikoner är från lagspel.
+            </div>
+        </div>
+    );
+};
+
+export default HogmodChart;

--- a/src/components/statistics/PlayerScoreChart.tsx
+++ b/src/components/statistics/PlayerScoreChart.tsx
@@ -5,6 +5,7 @@ import MahjongWinsChart from "./MahjongWinsChart";
 import HighRollerChart from "./HighRollerChart";
 import AverageHandTable from "./AverageHandTable";
 import BoxPlot from "./BoxPlot"
+import HogmodChart from "./HogmodChart"
 import { Tabs, Tab } from "@mui/material";
 import {
     GameWithHands,
@@ -77,6 +78,7 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
                 <Tab label="High Roller" />
                 <Tab label="Medelhänder" />
                 <Tab label="Distribution" />
+                <Tab label="Högmod" />
             </Tabs>
             <CustomTabPanel value={selectedTab} index={0}>
                 <PlayerScoresChart
@@ -104,6 +106,12 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
             </CustomTabPanel>
             <CustomTabPanel value={selectedTab} index={4}>
                 <BoxPlot
+                    stats={stats}
+                    includeTeams={includeTeams}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={5}>
+                <HogmodChart
                     stats={stats}
                     includeTeams={includeTeams}
                 />

--- a/src/lib/hogmodLabels.ts
+++ b/src/lib/hogmodLabels.ts
@@ -1,0 +1,8 @@
+export function getHogmodLabel(streakLength: number): string {
+    if (streakLength >= 7) return "Odödlig";
+    if (streakLength >= 6) return "Gudomlig";
+    if (streakLength >= 5) return "Kejsare";
+    if (streakLength >= 4) return "Tyrann";
+    if (streakLength >= 3) return "Storhetsvansinne";
+    return "Högmod";
+}

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -7,6 +7,13 @@ export interface HighRollerInfo {
     isTeam: boolean;
 }
 
+export interface HogmodInfo {
+    gameIndex: number;
+    streakLength: number;
+    hogmodIndex: string;
+    isTeam: boolean;
+}
+
 function uuidv4() {
     return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
         (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
@@ -26,6 +33,9 @@ export class PlayerData {
     public allScores: number[] = [];
     public allScoresNoTeams: number[] = [];
     public highRollers: HighRollerInfo[] = [];
+    public hogmodCount: number = 0;
+    public hogmodStreaks: HogmodInfo[] = [];
+    public longestHogmodStreak: number = 0;
     public averageHand: number = 0;
     public playerIds: string[];
     public color: string;
@@ -72,6 +82,19 @@ export class PlayerData {
                 highRollerIndex: uuidv4(),
                 isTeam: isPartOfTeam
             });
+        }
+    }
+
+    public addHogmod(gameIndex: number, streakLength: number, isTeam: boolean) {
+        this.hogmodCount++;
+        this.hogmodStreaks.push({
+            gameIndex,
+            streakLength,
+            hogmodIndex: uuidv4(),
+            isTeam,
+        });
+        if (streakLength > this.longestHogmodStreak) {
+            this.longestHogmodStreak = streakLength;
         }
     }
 
@@ -178,6 +201,41 @@ export class MahjongStats {
             });
             teamData.addHand(gameIndex, hand, false);
         });
+
+        this.processHogmod(game, gameIndex);
+    }
+
+    private processHogmod(game: GameWithHands, gameIndex: number) {
+        const roundMap = new Map<number, Hand[]>();
+        for (const hand of game.hands) {
+            if (!roundMap.has(hand.ROUND)) roundMap.set(hand.ROUND, []);
+            roundMap.get(hand.ROUND)!.push(hand);
+        }
+        const rounds = [...roundMap.keys()].sort((a, b) => a - b);
+
+        const teamEastStreak = new Map<string, number>();
+
+        for (const roundNum of rounds) {
+            const handsInRound = roundMap.get(roundNum)!;
+            for (const hand of handsInRound) {
+                const prevStreak = teamEastStreak.get(hand.TEAM_ID) || 0;
+                if (hand.WIND === 'E') {
+                    const newStreak = prevStreak + 1;
+                    teamEastStreak.set(hand.TEAM_ID, newStreak);
+                    if (newStreak >= 2) {
+                        const teamData = this.idToPlayerData[hand.TEAM_ID];
+                        teamData.addHogmod(gameIndex, newStreak, false);
+                        for (const playerId of teamData.playerIds) {
+                            this.idToPlayerData[playerId].addHogmod(
+                                gameIndex, newStreak, teamData.playerIds.length > 1
+                            );
+                        }
+                    }
+                } else {
+                    teamEastStreak.set(hand.TEAM_ID, 0);
+                }
+            }
+        }
     }
 
     public finish() {


### PR DESCRIPTION
## Changes

- **New Högmod Statistics Tab**: Added `HogmodChart` component to display Högmod (East wind streaks) statistics with visual representations using castle icons scaled by streak length
- **Escalating Streak Labels**: Created `hogmodLabels.ts` with dynamic labels for streak lengths (Högmod → Odödlig based on duration)
- **Streak Tracking**: Enhanced `matchChartClient.tsx` to track East wind streaks per team across rounds
- **Statistics Processing**: Added Högmod data collection in `statistics.ts` including:
  - Individual hogmod counts
  - Streak history with game indices
  - Longest streak tracking
  - Both individual and team-level statistics
- **UI Updates**: 
  - Updated `LastRoundDisplay.tsx` to use dynamic labels instead of static "Högmod" text
  - Added new "Högmod" tab to `PlayerScoreChart.tsx`

## Features
- Color-coded castle icons reflecting streak intensity (yellow to dark red)
- Tooltips showing game numbers and streak details
- Longest streak highlight with Swedish labels
- Team games marked with semi-transparency
- Comprehensive Högmod statistics per player/team