### PR TITLE
Add Storvinnare, Järnhand, Comeback, and Vindposition stats tabs

### DIFF
--- a/src/components/statistics/ComebackChart.tsx
+++ b/src/components/statistics/ComebackChart.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import {MahjongStats} from "@/lib/statistics";
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import {Tooltip} from "@mui/material";
+
+interface ComebackChartProps {
+    stats: MahjongStats;
+    readonly includeTeams: boolean;
+}
+
+const ComebackChart: React.FC<ComebackChartProps> = ({ stats, includeTeams }) => {
+    const playerStats = stats.getDataToShow(includeTeams);
+
+    const sorted = [...playerStats]
+        .filter(d => d.comebackGames.length > 0)
+        .sort((a, b) => b.comebackGames.length - a.comebackGames.length);
+
+    const biggestComeback = [...playerStats]
+        .flatMap(d => d.comebackGames.map(c => ({ ...c, playerName: d.name })))
+        .sort((a, b) => b.deficit - a.deficit)[0];
+
+    return (
+        <div style={{ paddingTop: "20px" }}>
+            <div style={{
+                marginBottom: "20px",
+                padding: "12px 16px",
+                backgroundColor: "#f5f5f5",
+                borderRadius: "8px",
+                color: "#555",
+                lineHeight: 1.5,
+            }}>
+                <strong>Comeback</strong> — registreras när en spelare vinner ett spel trots att ha legat på sista plats
+                under spelets gång. Ju större poängunderlaget var, desto mer imponerande comeback.
+            </div>
+
+            {biggestComeback && (
+                <div style={{
+                    marginBottom: "30px",
+                    padding: "16px",
+                    backgroundColor: "#e3f2fd",
+                    borderRadius: "8px",
+                    border: "1px solid #90caf9",
+                }}>
+                    <h3 style={{ margin: "0 0 8px 0" }}>
+                        Största comebacken
+                    </h3>
+                    <div style={{ fontSize: "1.2em" }}>
+                        <strong>{biggestComeback.playerName}</strong> — vände {biggestComeback.deficit} poängs underläge till vinst
+                        {" "}(spel #{biggestComeback.gameIndex + 1})
+                    </div>
+                </div>
+            )}
+
+            {sorted.length === 0 && (
+                <p style={{ fontStyle: "italic" }}>Inga comebacks registrerade.</p>
+            )}
+
+            {sorted.map((data) => (
+                <div key={data.id} style={{ marginBottom: "20px" }}>
+                    <h3 style={{ marginBottom: "4px" }}>{data.name}</h3>
+                    <div style={{ marginBottom: "8px", color: "#666" }}>
+                        Totalt: {data.comebackGames.length} comebacks
+                    </div>
+                    <div style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "8px",
+                        alignItems: "center",
+                    }}>
+                        {data.comebackGames.map((c) => {
+                            if (includeTeams && c.isTeam && data.isPlayer()) return null;
+                            const size = Math.min(20 + c.deficit / 10, 48);
+                            return (
+                                <Tooltip
+                                    key={c.comebackIndex}
+                                    title={`Spel #${c.gameIndex + 1}: Vände ${c.deficit} poängs underläge från sista plats`}
+                                >
+                                    <TrendingUpIcon
+                                        style={{
+                                            fontSize: size,
+                                            color: "#1976d2",
+                                            opacity: c.isTeam ? 0.5 : 1,
+                                        }}
+                                    />
+                                </Tooltip>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
+            {sorted.length > 0 && (
+                <div style={{ fontStyle: "italic", paddingTop: "20px", color: "#666" }}>
+                    Comeback = vann spelet trots att ha legat sist. Halvtransparenta ikoner är från lagspel.
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ComebackChart;

--- a/src/components/statistics/JarnhandChart.tsx
+++ b/src/components/statistics/JarnhandChart.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import {MahjongStats} from "@/lib/statistics";
+import {getJarnhandLabel} from "@/lib/jarnhandLabels";
+import ShieldIcon from '@mui/icons-material/Shield';
+import {Tooltip} from "@mui/material";
+
+interface JarnhandChartProps {
+    stats: MahjongStats;
+    readonly includeTeams: boolean;
+}
+
+const getIconSize = (streakLength: number) => {
+    const base = 20;
+    return base + (streakLength - 3) * 6;
+};
+
+const getStreakColor = (streakLength: number): string => {
+    if (streakLength >= 8) return "#1b5e20";
+    if (streakLength >= 7) return "#2e7d32";
+    if (streakLength >= 6) return "#388e3c";
+    if (streakLength >= 5) return "#43a047";
+    if (streakLength >= 4) return "#66bb6a";
+    return "#81c784";
+};
+
+const JarnhandChart: React.FC<JarnhandChartProps> = ({ stats, includeTeams }) => {
+    const playerStats = stats.getDataToShow(includeTeams);
+
+    const sorted = [...playerStats]
+        .filter(d => d.jarnhandCount > 0)
+        .sort((a, b) => b.jarnhandCount - a.jarnhandCount);
+
+    const longestStreakPlayer = [...playerStats]
+        .filter(d => d.longestJarnhandStreak > 0)
+        .sort((a, b) => b.longestJarnhandStreak - a.longestJarnhandStreak)[0];
+
+    return (
+        <div style={{ paddingTop: "20px" }}>
+            <div style={{
+                marginBottom: "20px",
+                padding: "12px 16px",
+                backgroundColor: "#f5f5f5",
+                borderRadius: "8px",
+                color: "#555",
+                lineHeight: 1.5,
+            }}>
+                <strong>Järnhand</strong> — räknar antal gånger en spelare har positivt resultat (pluspoäng) flera rundor i rad inom samma spel.
+                En svit på 3+ rundor med plusresultat registreras, och längre sviter ger eskalerande titlar:
+                Järnhand, Ståndaktig, Befäst, Okuvlig, Osårbar, Orubblig.
+            </div>
+
+            {longestStreakPlayer && (
+                <div style={{
+                    marginBottom: "30px",
+                    padding: "16px",
+                    backgroundColor: "#e8f5e9",
+                    borderRadius: "8px",
+                    border: "1px solid #a5d6a7",
+                }}>
+                    <h3 style={{ margin: "0 0 8px 0" }}>
+                        Längsta järnhand-sviten
+                    </h3>
+                    <div style={{ fontSize: "1.2em" }}>
+                        <strong>{longestStreakPlayer.name}</strong> — {longestStreakPlayer.longestJarnhandStreak} rundor med plusresultat
+                        {" "}({getJarnhandLabel(longestStreakPlayer.longestJarnhandStreak)})
+                    </div>
+                </div>
+            )}
+
+            {sorted.length === 0 && (
+                <p style={{ fontStyle: "italic" }}>Inga järnhand-sviter registrerade.</p>
+            )}
+
+            {sorted.map((data) => (
+                <div key={data.id} style={{ marginBottom: "20px" }}>
+                    <h3 style={{ marginBottom: "4px" }}>{data.name}</h3>
+                    <div style={{ marginBottom: "8px", color: "#666" }}>
+                        Totalt: {data.jarnhandCount} järnhand-sviter
+                        {data.longestJarnhandStreak >= 3 && (
+                            <> · Längsta svit: {data.longestJarnhandStreak} rundor ({getJarnhandLabel(data.longestJarnhandStreak)})</>
+                        )}
+                    </div>
+                    <div style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "6px",
+                        alignItems: "center",
+                    }}>
+                        {data.jarnhandStreaks.map((s) => {
+                            if (includeTeams && s.isTeam && data.isPlayer()) return null;
+                            const size = getIconSize(s.streakLength);
+                            return (
+                                <Tooltip
+                                    key={s.jarnhandIndex}
+                                    title={`Spel #${s.gameIndex + 1}: ${s.streakLength} rundor med plusresultat — ${getJarnhandLabel(s.streakLength)}`}
+                                >
+                                    <ShieldIcon
+                                        style={{
+                                            fontSize: size,
+                                            color: getStreakColor(s.streakLength),
+                                            opacity: s.isTeam ? 0.5 : 1,
+                                        }}
+                                    />
+                                </Tooltip>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
+            <div style={{ fontStyle: "italic", paddingTop: "20px", color: "#666" }}>
+                Halvtransparenta ikoner är från lagspel.
+            </div>
+        </div>
+    );
+};
+
+export default JarnhandChart;

--- a/src/components/statistics/PlayerScoreChart.tsx
+++ b/src/components/statistics/PlayerScoreChart.tsx
@@ -6,6 +6,10 @@ import HighRollerChart from "./HighRollerChart";
 import AverageHandTable from "./AverageHandTable";
 import BoxPlot from "./BoxPlot"
 import HogmodChart from "./HogmodChart"
+import StorvinnareChart from "./StorvinnareChart"
+import JarnhandChart from "./JarnhandChart"
+import ComebackChart from "./ComebackChart"
+import WindStatsChart from "./WindStatsChart"
 import { Tabs, Tab } from "@mui/material";
 import {
     GameWithHands,
@@ -79,6 +83,10 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
                 <Tab label="Medelhänder" />
                 <Tab label="Distribution" />
                 <Tab label="Högmod" />
+                <Tab label="Storvinnare" />
+                <Tab label="Järnhand" />
+                <Tab label="Comeback" />
+                <Tab label="Vindposition" />
             </Tabs>
             <CustomTabPanel value={selectedTab} index={0}>
                 <PlayerScoresChart
@@ -112,6 +120,30 @@ const PlayerScoreChart: React.FC<PlayerScoreChartProps> = ({
             </CustomTabPanel>
             <CustomTabPanel value={selectedTab} index={5}>
                 <HogmodChart
+                    stats={stats}
+                    includeTeams={includeTeams}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={6}>
+                <StorvinnareChart
+                    stats={stats}
+                    includeTeams={includeTeams}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={7}>
+                <JarnhandChart
+                    stats={stats}
+                    includeTeams={includeTeams}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={8}>
+                <ComebackChart
+                    stats={stats}
+                    includeTeams={includeTeams}
+                />
+            </CustomTabPanel>
+            <CustomTabPanel value={selectedTab} index={9}>
+                <WindStatsChart
                     stats={stats}
                     includeTeams={includeTeams}
                 />

--- a/src/components/statistics/StorvinnareChart.tsx
+++ b/src/components/statistics/StorvinnareChart.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import {MahjongStats} from "@/lib/statistics";
+import {getStorvinnareLabel} from "@/lib/storvinnareLabels";
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import {Tooltip} from "@mui/material";
+
+interface StorvinnareChartProps {
+    stats: MahjongStats;
+    readonly includeTeams: boolean;
+}
+
+const getIconSize = (streakLength: number) => {
+    const base = 20;
+    return base + (streakLength - 2) * 6;
+};
+
+const getStreakColor = (streakLength: number): string => {
+    if (streakLength >= 7) return "#b71c1c";
+    if (streakLength >= 6) return "#e65100";
+    if (streakLength >= 5) return "#f57f17";
+    if (streakLength >= 4) return "#ff8f00";
+    if (streakLength >= 3) return "#ffa000";
+    return "#ffc107";
+};
+
+const StorvinnareChart: React.FC<StorvinnareChartProps> = ({ stats, includeTeams }) => {
+    const playerStats = stats.getDataToShow(includeTeams);
+
+    const sorted = [...playerStats]
+        .filter(d => d.storvinnareCount > 0)
+        .sort((a, b) => b.storvinnareCount - a.storvinnareCount);
+
+    const longestStreakPlayer = [...playerStats]
+        .filter(d => d.longestStorvinnareStreak > 0)
+        .sort((a, b) => b.longestStorvinnareStreak - a.longestStorvinnareStreak)[0];
+
+    return (
+        <div style={{ paddingTop: "20px" }}>
+            <div style={{
+                marginBottom: "20px",
+                padding: "12px 16px",
+                backgroundColor: "#f5f5f5",
+                borderRadius: "8px",
+                color: "#555",
+                lineHeight: 1.5,
+            }}>
+                <strong>Storvinnare</strong> — räknar antal gånger en spelare vinner mahjong flera rundor i rad inom samma spel.
+                En svit på 2+ vinster i rad registreras, och längre sviter ger eskalerande titlar:
+                Storvinnare, Segrare, Champion, Mästare, Dominant, Oövervinnlig.
+            </div>
+
+            {longestStreakPlayer && (
+                <div style={{
+                    marginBottom: "30px",
+                    padding: "16px",
+                    backgroundColor: "#fff8e1",
+                    borderRadius: "8px",
+                    border: "1px solid #ffe082",
+                }}>
+                    <h3 style={{ margin: "0 0 8px 0" }}>
+                        Längsta vinstsviten
+                    </h3>
+                    <div style={{ fontSize: "1.2em" }}>
+                        <strong>{longestStreakPlayer.name}</strong> — {longestStreakPlayer.longestStorvinnareStreak} vinster i rad
+                        {" "}({getStorvinnareLabel(longestStreakPlayer.longestStorvinnareStreak)})
+                    </div>
+                </div>
+            )}
+
+            {sorted.length === 0 && (
+                <p style={{ fontStyle: "italic" }}>Inga vinstsviter registrerade.</p>
+            )}
+
+            {sorted.map((data) => (
+                <div key={data.id} style={{ marginBottom: "20px" }}>
+                    <h3 style={{ marginBottom: "4px" }}>{data.name}</h3>
+                    <div style={{ marginBottom: "8px", color: "#666" }}>
+                        Totalt: {data.storvinnareCount} vinstsviter
+                        {data.longestStorvinnareStreak >= 2 && (
+                            <> · Längsta svit: {data.longestStorvinnareStreak} vinster ({getStorvinnareLabel(data.longestStorvinnareStreak)})</>
+                        )}
+                    </div>
+                    <div style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "6px",
+                        alignItems: "center",
+                    }}>
+                        {data.storvinnareStreaks.map((s) => {
+                            if (includeTeams && s.isTeam && data.isPlayer()) return null;
+                            const size = getIconSize(s.streakLength);
+                            return (
+                                <Tooltip
+                                    key={s.storvinnareIndex}
+                                    title={`Spel #${s.gameIndex + 1}: ${s.streakLength} vinster i rad — ${getStorvinnareLabel(s.streakLength)}`}
+                                >
+                                    <EmojiEventsIcon
+                                        style={{
+                                            fontSize: size,
+                                            color: getStreakColor(s.streakLength),
+                                            opacity: s.isTeam ? 0.5 : 1,
+                                        }}
+                                    />
+                                </Tooltip>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
+            <div style={{ fontStyle: "italic", paddingTop: "20px", color: "#666" }}>
+                Halvtransparenta ikoner är från lagspel.
+            </div>
+        </div>
+    );
+};
+
+export default StorvinnareChart;

--- a/src/components/statistics/WindStatsChart.tsx
+++ b/src/components/statistics/WindStatsChart.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import {MahjongStats} from "@/lib/statistics";
+
+interface WindStatsChartProps {
+    stats: MahjongStats;
+    readonly includeTeams: boolean;
+}
+
+const WINDS = [
+    { key: "E", label: "Öst" },
+    { key: "N", label: "Nord" },
+    { key: "W", label: "Väst" },
+    { key: "S", label: "Syd" },
+] as const;
+
+const WindStatsChart: React.FC<WindStatsChartProps> = ({ stats, includeTeams }) => {
+    const playerStats = stats.getDataToShow(includeTeams)
+        .filter(d => d.numHands > 0);
+
+    return (
+        <div style={{ paddingTop: "20px", overflowX: "auto" }}>
+            <div style={{
+                marginBottom: "20px",
+                padding: "12px 16px",
+                backgroundColor: "#f5f5f5",
+                borderRadius: "8px",
+                color: "#555",
+                lineHeight: 1.5,
+            }}>
+                <strong>Vindposition</strong> — visar hur ofta en spelare vinner mahjong beroende på vilken vindposition
+                (Öst, Nord, Väst, Syd) de sitter på. Procenten anger andelen rundor i den positionen som resulterade i mahjong-vinst.
+            </div>
+
+            {playerStats.length === 0 && (
+                <p style={{ fontStyle: "italic" }}>Ingen data tillgänglig.</p>
+            )}
+
+            {playerStats.length > 0 && (
+                <table style={{
+                    width: "100%",
+                    borderCollapse: "collapse",
+                    fontSize: "0.95em",
+                }}>
+                    <thead>
+                        <tr style={{ borderBottom: "2px solid #ddd" }}>
+                            <th style={{ textAlign: "left", padding: "8px 12px" }}>Spelare</th>
+                            {WINDS.map(w => (
+                                <th key={w.key} style={{ textAlign: "center", padding: "8px 12px" }}>
+                                    {w.label}
+                                </th>
+                            ))}
+                            <th style={{ textAlign: "center", padding: "8px 12px" }}>Totalt</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {playerStats.map((data) => {
+                            const totalWins = WINDS.reduce((sum, w) => sum + data.windWins[w.key], 0);
+                            const totalHands = WINDS.reduce((sum, w) => sum + data.windHands[w.key], 0);
+
+                            const windRates = WINDS.map(w => {
+                                const hands = data.windHands[w.key];
+                                const wins = data.windWins[w.key];
+                                return hands > 0 ? (wins / hands) * 100 : null;
+                            });
+
+                            const validRates = windRates.filter((r): r is number => r !== null);
+                            const maxRate = validRates.length > 0 ? Math.max(...validRates) : null;
+
+                            return (
+                                <tr key={data.id} style={{ borderBottom: "1px solid #eee" }}>
+                                    <td style={{ padding: "8px 12px", fontWeight: "bold" }}>
+                                        {data.name}
+                                    </td>
+                                    {WINDS.map((w, i) => {
+                                        const rate = windRates[i];
+                                        const hands = data.windHands[w.key];
+                                        const wins = data.windWins[w.key];
+                                        const isBest = rate !== null && rate === maxRate && rate > 0;
+                                        return (
+                                            <td key={w.key} style={{
+                                                textAlign: "center",
+                                                padding: "8px 12px",
+                                                backgroundColor: isBest ? "#e8f5e9" : undefined,
+                                                fontWeight: isBest ? "bold" : undefined,
+                                            }}>
+                                                {rate !== null ? (
+                                                    <>
+                                                        {rate.toFixed(1)}%
+                                                        <div style={{ fontSize: "0.8em", color: "#999" }}>
+                                                            {wins}/{hands}
+                                                        </div>
+                                                    </>
+                                                ) : "—"}
+                                            </td>
+                                        );
+                                    })}
+                                    <td style={{ textAlign: "center", padding: "8px 12px" }}>
+                                        {totalHands > 0 ? (
+                                            <>
+                                                {((totalWins / totalHands) * 100).toFixed(1)}%
+                                                <div style={{ fontSize: "0.8em", color: "#999" }}>
+                                                    {totalWins}/{totalHands}
+                                                </div>
+                                            </>
+                                        ) : "—"}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            )}
+
+            <div style={{ fontStyle: "italic", paddingTop: "20px", color: "#666" }}>
+                Visar andel mahjong-vinster per vindposition. Grön markering = bästa vindposition.
+            </div>
+        </div>
+    );
+};
+
+export default WindStatsChart;

--- a/src/lib/jarnhandLabels.ts
+++ b/src/lib/jarnhandLabels.ts
@@ -1,0 +1,8 @@
+export function getJarnhandLabel(streakLength: number): string {
+    if (streakLength >= 8) return "Orubblig";
+    if (streakLength >= 7) return "Osårbar";
+    if (streakLength >= 6) return "Okuvlig";
+    if (streakLength >= 5) return "Befäst";
+    if (streakLength >= 4) return "Ståndaktig";
+    return "Järnhand";
+}

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -14,6 +14,36 @@ export interface HogmodInfo {
     isTeam: boolean;
 }
 
+export interface StorvinnareInfo {
+    gameIndex: number;
+    streakLength: number;
+    storvinnareIndex: string;
+    isTeam: boolean;
+}
+
+export interface JarnhandInfo {
+    gameIndex: number;
+    streakLength: number;
+    jarnhandIndex: string;
+    isTeam: boolean;
+}
+
+export interface ComebackInfo {
+    gameIndex: number;
+    lowestPosition: number;
+    deficit: number;
+    comebackIndex: string;
+    isTeam: boolean;
+}
+
+export interface WindRecord {
+    E: number;
+    N: number;
+    W: number;
+    S: number;
+    [key: string]: number;
+}
+
 function uuidv4() {
     return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
         (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
@@ -36,6 +66,15 @@ export class PlayerData {
     public hogmodCount: number = 0;
     public hogmodStreaks: HogmodInfo[] = [];
     public longestHogmodStreak: number = 0;
+    public storvinnareCount: number = 0;
+    public storvinnareStreaks: StorvinnareInfo[] = [];
+    public longestStorvinnareStreak: number = 0;
+    public jarnhandCount: number = 0;
+    public jarnhandStreaks: JarnhandInfo[] = [];
+    public longestJarnhandStreak: number = 0;
+    public comebackGames: ComebackInfo[] = [];
+    public windWins: WindRecord = { E: 0, N: 0, W: 0, S: 0 };
+    public windHands: WindRecord = { E: 0, N: 0, W: 0, S: 0 };
     public averageHand: number = 0;
     public playerIds: string[];
     public color: string;
@@ -75,6 +114,12 @@ export class PlayerData {
             this.allScoresNoTeams.push(hand.HAND_SCORE);
         }
         this.numHands++;
+        if (hand.WIND in this.windHands) {
+            this.windHands[hand.WIND]++;
+            if (hand.IS_WINNER) {
+                this.windWins[hand.WIND]++;
+            }
+        }
         if (hand.HAND > 100) {
             this.highRollers.push({
                 gameIndex: gameIndex,
@@ -96,6 +141,42 @@ export class PlayerData {
         if (streakLength > this.longestHogmodStreak) {
             this.longestHogmodStreak = streakLength;
         }
+    }
+
+    public addStorvinnare(gameIndex: number, streakLength: number, isTeam: boolean) {
+        this.storvinnareCount++;
+        this.storvinnareStreaks.push({
+            gameIndex,
+            streakLength,
+            storvinnareIndex: uuidv4(),
+            isTeam,
+        });
+        if (streakLength > this.longestStorvinnareStreak) {
+            this.longestStorvinnareStreak = streakLength;
+        }
+    }
+
+    public addJarnhand(gameIndex: number, streakLength: number, isTeam: boolean) {
+        this.jarnhandCount++;
+        this.jarnhandStreaks.push({
+            gameIndex,
+            streakLength,
+            jarnhandIndex: uuidv4(),
+            isTeam,
+        });
+        if (streakLength > this.longestJarnhandStreak) {
+            this.longestJarnhandStreak = streakLength;
+        }
+    }
+
+    public addComeback(gameIndex: number, lowestPosition: number, deficit: number, isTeam: boolean) {
+        this.comebackGames.push({
+            gameIndex,
+            lowestPosition,
+            deficit,
+            comebackIndex: uuidv4(),
+            isTeam,
+        });
     }
 
     public finish() {
@@ -203,6 +284,9 @@ export class MahjongStats {
         });
 
         this.processHogmod(game, gameIndex);
+        this.processStorvinnare(game, gameIndex);
+        this.processJarnhand(game, gameIndex);
+        this.processComeback(game, gameIndex);
     }
 
     private processHogmod(game: GameWithHands, gameIndex: number) {
@@ -238,9 +322,130 @@ export class MahjongStats {
         }
     }
 
+    private processStorvinnare(game: GameWithHands, gameIndex: number) {
+        const roundMap = new Map<number, Hand[]>();
+        for (const hand of game.hands) {
+            if (!roundMap.has(hand.ROUND)) roundMap.set(hand.ROUND, []);
+            roundMap.get(hand.ROUND)!.push(hand);
+        }
+        const rounds = [...roundMap.keys()].sort((a, b) => a - b);
+
+        const teamWinStreak = new Map<string, number>();
+
+        for (const roundNum of rounds) {
+            const handsInRound = roundMap.get(roundNum)!;
+            for (const hand of handsInRound) {
+                const prevStreak = teamWinStreak.get(hand.TEAM_ID) || 0;
+                if (hand.IS_WINNER) {
+                    const newStreak = prevStreak + 1;
+                    teamWinStreak.set(hand.TEAM_ID, newStreak);
+                    if (newStreak >= 2) {
+                        const teamData = this.idToPlayerData[hand.TEAM_ID];
+                        teamData.addStorvinnare(gameIndex, newStreak, false);
+                        for (const playerId of teamData.playerIds) {
+                            this.idToPlayerData[playerId].addStorvinnare(
+                                gameIndex, newStreak, teamData.playerIds.length > 1
+                            );
+                        }
+                    }
+                } else {
+                    teamWinStreak.set(hand.TEAM_ID, 0);
+                }
+            }
+        }
+    }
+
+    private processJarnhand(game: GameWithHands, gameIndex: number) {
+        const roundMap = new Map<number, Hand[]>();
+        for (const hand of game.hands) {
+            if (!roundMap.has(hand.ROUND)) roundMap.set(hand.ROUND, []);
+            roundMap.get(hand.ROUND)!.push(hand);
+        }
+        const rounds = [...roundMap.keys()].sort((a, b) => a - b);
+
+        const teamPositiveStreak = new Map<string, number>();
+
+        for (const roundNum of rounds) {
+            const handsInRound = roundMap.get(roundNum)!;
+            for (const hand of handsInRound) {
+                const prevStreak = teamPositiveStreak.get(hand.TEAM_ID) || 0;
+                if (hand.HAND_SCORE > 0) {
+                    const newStreak = prevStreak + 1;
+                    teamPositiveStreak.set(hand.TEAM_ID, newStreak);
+                    if (newStreak >= 3) {
+                        const teamData = this.idToPlayerData[hand.TEAM_ID];
+                        teamData.addJarnhand(gameIndex, newStreak, false);
+                        for (const playerId of teamData.playerIds) {
+                            this.idToPlayerData[playerId].addJarnhand(
+                                gameIndex, newStreak, teamData.playerIds.length > 1
+                            );
+                        }
+                    }
+                } else {
+                    teamPositiveStreak.set(hand.TEAM_ID, 0);
+                }
+            }
+        }
+    }
+
+    private processComeback(game: GameWithHands, gameIndex: number) {
+        const roundMap = new Map<number, Hand[]>();
+        for (const hand of game.hands) {
+            if (!roundMap.has(hand.ROUND)) roundMap.set(hand.ROUND, []);
+            roundMap.get(hand.ROUND)!.push(hand);
+        }
+        const rounds = [...roundMap.keys()].sort((a, b) => a - b);
+
+        const teamIds = [game.TEAM_ID_1, game.TEAM_ID_2, game.TEAM_ID_3, game.TEAM_ID_4];
+        const cumulativeScores = new Map<string, number>();
+        const wasInLast = new Map<string, boolean>();
+        const maxDeficit = new Map<string, number>();
+
+        for (const teamId of teamIds) {
+            cumulativeScores.set(teamId, 0);
+            wasInLast.set(teamId, false);
+            maxDeficit.set(teamId, 0);
+        }
+
+        for (const roundNum of rounds) {
+            const handsInRound = roundMap.get(roundNum)!;
+            for (const hand of handsInRound) {
+                cumulativeScores.set(hand.TEAM_ID,
+                    (cumulativeScores.get(hand.TEAM_ID) || 0) + hand.HAND_SCORE);
+            }
+
+            // Determine positions after this round
+            const sorted = [...cumulativeScores.entries()]
+                .sort((a, b) => b[1] - a[1]);
+            const lastTeamId = sorted[sorted.length - 1][0];
+            const leaderScore = sorted[0][1];
+            const lastScore = sorted[sorted.length - 1][1];
+
+            wasInLast.set(lastTeamId, true);
+            const currentDeficit = leaderScore - lastScore;
+            if (currentDeficit > (maxDeficit.get(lastTeamId) || 0)) {
+                maxDeficit.set(lastTeamId, currentDeficit);
+            }
+        }
+
+        // Find winner (highest cumulative score at end)
+        const finalSorted = [...cumulativeScores.entries()]
+            .sort((a, b) => b[1] - a[1]);
+        const winnerTeamId = finalSorted[0][0];
+
+        if (wasInLast.get(winnerTeamId)) {
+            const deficit = maxDeficit.get(winnerTeamId) || 0;
+            const teamData = this.idToPlayerData[winnerTeamId];
+            teamData.addComeback(gameIndex, teamIds.length, deficit, false);
+            for (const playerId of teamData.playerIds) {
+                this.idToPlayerData[playerId].addComeback(
+                    gameIndex, teamIds.length, deficit, teamData.playerIds.length > 1
+                );
+            }
+        }
+    }
+
     public finish() {
         Object.values(this.idToPlayerData).forEach((data) => { data.finish(); })
     }
-
-
 }

--- a/src/lib/storvinnareLabels.ts
+++ b/src/lib/storvinnareLabels.ts
@@ -1,0 +1,8 @@
+export function getStorvinnareLabel(streakLength: number): string {
+    if (streakLength >= 7) return "Oövervinnlig";
+    if (streakLength >= 6) return "Dominant";
+    if (streakLength >= 5) return "Mästare";
+    if (streakLength >= 4) return "Champion";
+    if (streakLength >= 3) return "Segrare";
+    return "Storvinnare";
+}


### PR DESCRIPTION
## Overview
Adds four new statistics tabs to the player score chart:

### New Components
- **StorvinnareChart** - Tracks consecutive mahjong wins within games (2+ consecutive wins)
- **JarnhandChart** - Tracks consecutive rounds with positive scores within games (3+ consecutive rounds)
- **ComebackChart** - Highlights games where a player wins after being in last place
- **WindStatsChart** - Shows win percentage by wind position (East, North, West, South)

### Changes to Statistics Engine
- Added tracking for consecutive win streaks (`storvinnareStreaks`, `longestStorvinnareStreak`)
- Added tracking for consecutive positive score streaks (`jarnhandStreaks`, `longestJarnhandStreak`)
- Added comeback tracking (`comebackGames`) with deficit calculation
- Added wind position statistics (`windWins`, `windHands`)
- Implemented three new processing methods in `MahjongStats` class

### Label Systems
- Created `storvinnareLabels.ts` with escalating titles (Storvinnare → Oövervinnlig)
- Created `jarnhandLabels.ts` with escalating titles (Järnhand → Orubblig)

### UI Features
- Visual indicators (trophy and shield icons) sized based on streak length
- Color-coded styling for different achievement levels
- Informational headers explaining each metric
- Support for team vs. individual statistics filtering